### PR TITLE
feat: AST v1 refactor — entities, signals, entity resolution

### DIFF
--- a/scripts/seed-entities.ts
+++ b/scripts/seed-entities.ts
@@ -1,0 +1,175 @@
+/**
+ * Seed entities + entity_aliases from the existing GAMING_COMPANIES array.
+ * One-time migration script that:
+ * 1. Reads GAMING_COMPANIES from companies.ts
+ * 2. Inserts canonical entities into the entities table
+ * 3. Inserts all aliases (including canonical name) into entity_aliases
+ *
+ * Run with: npx tsx scripts/seed-entities.ts
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { GAMING_COMPANIES, CompanyData } from "../src/lib/companies";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error("❌ Missing SUPABASE env vars");
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+interface Entity {
+  id: string;
+  canonical_name: string;
+  entity_type: string;
+  ticker: string | null;
+  exchange: string | null;
+  is_public: boolean;
+  parent_id: string | null;
+  description: string | null;
+}
+
+interface EntityAlias {
+  entity_id: string;
+  alias: string;
+  alias_type: string;
+}
+
+async function seedEntities() {
+  console.log(`🌱 Seeding ${GAMING_COMPANIES.length} entities...`);
+
+  const entities: Omit<Entity, "id">[] = [];
+  const aliasMap = new Map<string, EntityAlias[]>(); // canonical_name -> aliases
+  const parentMap = new Map<string, string>(); // child canonical_name -> parent canonical_name
+
+  // Phase 1: Build entities and record parent relationships
+  for (const company of GAMING_COMPANIES) {
+    const isPublic = !company.isPrivate && company.ticker !== "";
+
+    entities.push({
+      canonical_name: company.name,
+      entity_type: "company",
+      ticker: company.ticker || null,
+      exchange: company.exchange || null,
+      is_public: isPublic,
+      parent_id: null, // will resolve in phase 2
+      description: company.segment || null,
+    });
+
+    // Build alias list
+    const aliases: EntityAlias[] = [];
+
+    // Canonical name is an alias too
+    aliases.push({
+      entity_id: "", // will fill after insert
+      alias: company.name,
+      alias_type: "canonical",
+    });
+
+    // Ticker is an alias
+    if (company.ticker && company.ticker !== "") {
+      aliases.push({
+        entity_id: "",
+        alias: company.ticker,
+        alias_type: "ticker",
+      });
+    }
+
+    // All other aliases
+    for (const alias of company.aliases) {
+      aliases.push({
+        entity_id: "",
+        alias: alias,
+        alias_type: "common",
+      });
+    }
+
+    aliasMap.set(company.name, aliases);
+
+    // Record parent relationship for phase 2
+    if (company.parentCompany) {
+      parentMap.set(company.name, company.parentCompany);
+    }
+  }
+
+  // Phase 2: Insert entities and get UUIDs
+  console.log("📦 Inserting entities...");
+  const { data: insertedEntities, error: entityError } = await supabase
+    .from("entities")
+    .insert(entities)
+    .select();
+
+  if (entityError) {
+    console.error("❌ Error inserting entities:", entityError);
+    process.exit(1);
+  }
+
+  console.log(`✅ Inserted ${insertedEntities.length} entities`);
+
+  // Build canonical_name -> uuid map
+  const nameToId = new Map<string, string>();
+  for (const entity of insertedEntities) {
+    nameToId.set(entity.canonical_name, entity.id);
+  }
+
+  // Phase 3: Resolve parent_id FKs
+  console.log("🔗 Resolving parent relationships...");
+  for (const [childName, parentName] of parentMap.entries()) {
+    const childId = nameToId.get(childName);
+    const parentId = nameToId.get(parentName);
+
+    if (!childId || !parentId) {
+      console.warn(`⚠️  Could not resolve parent relationship: ${childName} -> ${parentName}`);
+      continue;
+    }
+
+    const { error: updateError } = await supabase
+      .from("entities")
+      .update({ parent_id: parentId })
+      .eq("id", childId);
+
+    if (updateError) {
+      console.error(`❌ Error updating parent_id for ${childName}:`, updateError);
+    }
+  }
+
+  // Phase 4: Insert aliases
+  console.log("🏷️  Inserting aliases...");
+  const allAliases: EntityAlias[] = [];
+
+  for (const entity of insertedEntities) {
+    const aliases = aliasMap.get(entity.canonical_name);
+    if (!aliases) continue;
+
+    for (const alias of aliases) {
+      allAliases.push({
+        entity_id: entity.id,
+        alias: alias.alias,
+        alias_type: alias.alias_type,
+      });
+    }
+  }
+
+  const { error: aliasError } = await supabase
+    .from("entity_aliases")
+    .insert(allAliases);
+
+  if (aliasError) {
+    console.error("❌ Error inserting aliases:", aliasError);
+    process.exit(1);
+  }
+
+  console.log(`✅ Inserted ${allAliases.length} aliases`);
+  console.log("🎉 Seed complete!");
+}
+
+seedEntities().catch((err) => {
+  console.error("❌ Seed failed:", err);
+  process.exit(1);
+});

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -96,6 +96,7 @@ export interface Database {
           value: string;
           confidence: number | null;
           manual: boolean;
+          entity_id: string | null; // MANUALLY ADDED — pending migration 006_item_tags_entity_fk.sql
         };
         Insert: {
           id?: string;
@@ -104,6 +105,7 @@ export interface Database {
           value: string;
           confidence?: number | null;
           manual?: boolean;
+          entity_id?: string | null; // MANUALLY ADDED — pending migration 006_item_tags_entity_fk.sql
         };
         Update: {
           id?: string;
@@ -112,6 +114,7 @@ export interface Database {
           value?: string;
           confidence?: number | null;
           manual?: boolean;
+          entity_id?: string | null; // MANUALLY ADDED — pending migration 006_item_tags_entity_fk.sql
         };
       };
       companies: {
@@ -173,6 +176,39 @@ export interface Database {
           errors?: string[];
           success?: boolean;
           duration_ms?: number;
+        };
+      };
+      // MANUALLY ADDED — pending migration 007_signals.sql + supabase gen types regen
+      signals: {
+        Row: {
+          id: string;
+          item_id: string;
+          signal_type: 'acquisition' | 'fundraising' | 'earnings' | 'layoffs' | 'leadership' | 'product_launch' | 'regulatory' | 'platform_change' | 'macro';
+          summary: string;
+          investment_relevance_score: number;
+          raw_llm_output: Json | null;
+          model_used: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          item_id: string;
+          signal_type: 'acquisition' | 'fundraising' | 'earnings' | 'layoffs' | 'leadership' | 'product_launch' | 'regulatory' | 'platform_change' | 'macro';
+          summary: string;
+          investment_relevance_score: number;
+          raw_llm_output?: Json | null;
+          model_used?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          item_id?: string;
+          signal_type?: 'acquisition' | 'fundraising' | 'earnings' | 'layoffs' | 'leadership' | 'product_launch' | 'regulatory' | 'platform_change' | 'macro';
+          summary?: string;
+          investment_relevance_score?: number;
+          raw_llm_output?: Json | null;
+          model_used?: string | null;
+          created_at?: string;
         };
       };
     };

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1,6 +1,7 @@
 import Parser from "rss-parser";
 import { createClient } from "@supabase/supabase-js";
 import { tagItem, tagItemWithAI } from "./tagger";
+import { extractSignal } from "./signal-extractor";
 
 const parser = new Parser({
   timeout: 8000, // Reduced from 15s for faster failure on stale feeds
@@ -51,6 +52,7 @@ interface SourceRow {
 }
 
 // Lazy singleton - avoids creating new client on every call
+// TODO: type as ReturnType<typeof createClient<Database>> after migrations run + types regenerated
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _supabase: any = null;
 function getSupabase() {
@@ -151,6 +153,62 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
           await supabase
             .from("item_tags")
             .upsert(allTagRows, { onConflict: "item_id,dimension,value", ignoreDuplicates: true });
+        }
+
+        // Step 4: Entity resolution + signal extraction
+        // For each item, resolve company tags to entity_ids, then try to extract signal
+        for (const { id, tags } of itemsWithTags) {
+          try {
+            // Resolve entities for company tags
+            const companyTags = tags.company || [];
+            let hasResolvedEntity = false;
+
+            if (companyTags.length > 0) {
+              // Query entity_aliases to resolve company names to entity_ids
+              const { data: aliases } = await supabase
+                .from("entity_aliases")
+                .select("alias, entity_id")
+                .in("alias", companyTags.map((c: string) => c.toLowerCase()));
+
+              if (aliases && aliases.length > 0) {
+                hasResolvedEntity = true;
+
+                // Build a map of alias -> entity_id
+                const aliasMap = new Map(aliases.map((a: { alias: string; entity_id: string }) => [a.alias.toLowerCase(), a.entity_id]));
+
+                // Update item_tags rows with entity_id
+                for (const company of companyTags) {
+                  const entityId = aliasMap.get(company.toLowerCase());
+                  if (entityId) {
+                    await supabase
+                      .from("item_tags")
+                      .update({ entity_id: entityId })
+                      .eq("item_id", id)
+                      .eq("dimension", "company")
+                      .eq("value", company);
+                  }
+                }
+              }
+            }
+
+            // Try signal extraction (non-blocking, errors logged internally)
+            const itemForSignal = {
+              id,
+              title: data.find((d: { id: string }) => d.id === id)?.title || "",
+              content: data.find((d: { id: string }) => d.id === id)?.content || null,
+              tags,
+              sources: { source_type: source.source_type },
+            };
+
+            await extractSignal({
+              supabase,
+              item: itemForSignal,
+              hasResolvedEntity,
+            });
+          } catch (err) {
+            // Entity resolution or signal extraction failed — log but don't break ingestion
+            console.warn(`[ingest] Entity resolution/signal extraction failed for item ${id}:`, err);
+          }
         }
       }
     }

--- a/src/lib/signal-extractor.ts
+++ b/src/lib/signal-extractor.ts
@@ -1,0 +1,217 @@
+/**
+ * Signal extraction pipeline for AST.
+ *
+ * Handles:
+ * 1. Signal gate — determines if an item is worth extracting a signal from
+ * 2. LLM extraction — calls OpenAI to synthesize signal_type + summary + investment_relevance_score
+ * 3. Writes to signals table
+ *
+ * Signal extraction MUST NOT break ingestion — all errors are caught and logged.
+ */
+
+import { scoreItem } from "./importance";
+import type { Database } from "./database.types";
+
+// Type for the signals insert payload (at least this is checked)
+type SignalInsert = Database["public"]["Tables"]["signals"]["Insert"];
+
+// ── Gate Logic ─────────────────────────────────────────────────────
+
+interface ItemForGate {
+  id: string;
+  title: string;
+  content: string | null;
+  tags: Record<string, string[]>;
+  sources?: { source_type: string };
+}
+
+/**
+ * Determine if an item should have a signal extracted.
+ *
+ * Gate fires if:
+ * - importance_score >= 0.4 AND category is one of [earnings, m-and-a, fundraising, layoffs, leadership, regulatory]
+ * - OR: at least one entity is resolved (company tag with entity_id) AND category is not null
+ */
+export function shouldExtractSignal(
+  item: ItemForGate,
+  importanceScore: number,
+  hasResolvedEntity: boolean
+): boolean {
+  const categories = item.tags.category || [];
+  const highValueCategories = ["earnings", "m-and-a", "fundraising", "layoffs", "leadership", "regulatory"];
+
+  // Path 1: High importance + high value category
+  if (importanceScore >= 0.4 && categories.some((cat) => highValueCategories.includes(cat))) {
+    return true;
+  }
+
+  // Path 2: Has entity + has category
+  if (hasResolvedEntity && categories.length > 0) {
+    return true;
+  }
+
+  return false;
+}
+
+// ── LLM Extraction ─────────────────────────────────────────────────
+
+interface SignalExtractionResult {
+  signal_type:
+    | "acquisition"
+    | "fundraising"
+    | "earnings"
+    | "layoffs"
+    | "leadership"
+    | "product_launch"
+    | "regulatory"
+    | "platform_change"
+    | "macro";
+  summary: string;
+  investment_relevance_score: number;
+  reasoning: string;
+}
+
+const SIGNAL_EXTRACTION_PROMPT = `You are an investment analyst specializing in the gaming industry. Extract a structured signal from the following article.
+
+Return a JSON object with:
+- signal_type: one of [acquisition, fundraising, earnings, layoffs, leadership, product_launch, regulatory, platform_change, macro]
+- summary: one concise sentence describing what happened and why it matters for investors (max 200 chars)
+- investment_relevance_score: float 0-1 (0 = noise, 1 = market-moving event)
+- reasoning: brief explanation of the score (1-2 sentences)
+
+Article title: {TITLE}
+Article content: {CONTENT}
+
+Respond with valid JSON only, no markdown fences.`;
+
+/**
+ * Call OpenAI to extract signal from item.
+ * Hard timeout: 6s.
+ */
+async function extractSignalWithLLM(
+  title: string,
+  content: string | null
+): Promise<SignalExtractionResult | null> {
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (!openaiKey) {
+    console.warn("[signal-extractor] OPENAI_API_KEY not set, skipping LLM extraction");
+    return null;
+  }
+
+  const prompt = SIGNAL_EXTRACTION_PROMPT.replace("{TITLE}", title).replace(
+    "{CONTENT}",
+    content?.slice(0, 2000) || "(no content)"
+  );
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 6000);
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${openaiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.3,
+        max_tokens: 300,
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      console.warn(`[signal-extractor] OpenAI API error: ${response.status} ${response.statusText}`);
+      return null;
+    }
+
+    const data = await response.json();
+    const text = data.choices?.[0]?.message?.content?.trim();
+    if (!text) return null;
+
+    // Parse JSON response
+    const parsed = JSON.parse(text) as SignalExtractionResult;
+
+    // Validate shape
+    if (
+      !parsed.signal_type ||
+      !parsed.summary ||
+      typeof parsed.investment_relevance_score !== "number"
+    ) {
+      console.warn("[signal-extractor] Invalid response shape from OpenAI");
+      return null;
+    }
+
+    return parsed;
+  } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      console.warn("[signal-extractor] LLM call timed out after 6s");
+    } else {
+      console.warn("[signal-extractor] LLM call failed:", err);
+    }
+    return null;
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────
+
+interface ExtractSignalOptions {
+  supabase: any; // TODO: type as SupabaseClient<Database> after migrations run + types regenerated
+  item: {
+    id: string;
+    title: string;
+    content: string | null;
+    tags: Record<string, string[]>;
+    sources?: { source_type: string };
+  };
+  hasResolvedEntity: boolean;
+}
+
+/**
+ * Extract and store signal for an item if it passes the gate.
+ * Non-throwing — all errors are caught and logged.
+ */
+export async function extractSignal(options: ExtractSignalOptions): Promise<void> {
+  const { supabase, item, hasResolvedEntity } = options;
+
+  try {
+    // Compute importance score (gate dependency)
+    const importanceScore = scoreItem(item as Parameters<typeof scoreItem>[0]);
+
+    // Check gate
+    if (!shouldExtractSignal(item, importanceScore, hasResolvedEntity)) {
+      return; // Silent — gate didn't fire
+    }
+
+    // Extract signal via LLM
+    const signal = await extractSignalWithLLM(item.title, item.content);
+    if (!signal) {
+      // LLM failed or timed out — log but don't break ingestion
+      console.warn(`[signal-extractor] Failed to extract signal for item ${item.id}`);
+      return;
+    }
+
+    // Write to signals table
+    const payload: SignalInsert = {
+      item_id: item.id,
+      signal_type: signal.signal_type,
+      summary: signal.summary,
+      investment_relevance_score: signal.investment_relevance_score,
+      raw_llm_output: signal as unknown as SignalInsert["raw_llm_output"],
+      model_used: "gpt-4o-mini",
+    };
+
+    const { error } = await supabase.from("signals").insert(payload);
+
+    if (error) {
+      console.warn(`[signal-extractor] Failed to write signal for item ${item.id}:`, error.message);
+    }
+  } catch (err) {
+    // Catch-all — signal extraction must never break ingestion
+    console.error(`[signal-extractor] Unexpected error for item ${item.id}:`, err);
+  }
+}

--- a/supabase/migrations/004_entities.sql
+++ b/supabase/migrations/004_entities.sql
@@ -1,0 +1,25 @@
+-- 004: Entities table
+-- Replaces companies table with type-aware entity model
+
+CREATE TABLE entities (
+  id              uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  canonical_name  text NOT NULL UNIQUE,
+  entity_type     text NOT NULL CHECK (entity_type IN (
+                    'company', 'person', 'game', 'event', 'org'
+                  )),
+  ticker          text,
+  exchange        text,
+  is_public       boolean DEFAULT false,
+  parent_id       uuid REFERENCES entities(id) ON DELETE SET NULL,
+  description     text,
+  created_at      timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_entities_type ON entities(entity_type);
+CREATE INDEX idx_entities_ticker ON entities(ticker) WHERE ticker IS NOT NULL;
+
+-- RLS (match existing pattern — service role only)
+ALTER TABLE entities ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON entities
+  FOR ALL USING (true) WITH CHECK (true);

--- a/supabase/migrations/005_entity_aliases.sql
+++ b/supabase/migrations/005_entity_aliases.sql
@@ -1,0 +1,22 @@
+-- 005: Entity aliases table
+-- The deduplication layer for entity name resolution
+
+CREATE TABLE entity_aliases (
+  id          uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  entity_id   uuid NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  alias       text NOT NULL,
+  alias_type  text NOT NULL CHECK (alias_type IN (
+                'canonical', 'ticker', 'common', 'game_title',
+                'abbreviation', 'former_name', 'product'
+              )),
+  UNIQUE (alias)  -- one alias maps to exactly one entity
+);
+
+CREATE INDEX idx_entity_aliases_alias ON entity_aliases(lower(alias));
+CREATE INDEX idx_entity_aliases_entity ON entity_aliases(entity_id);
+
+-- RLS (match existing pattern — service role only)
+ALTER TABLE entity_aliases ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON entity_aliases
+  FOR ALL USING (true) WITH CHECK (true);

--- a/supabase/migrations/006_item_tags_entity_fk.sql
+++ b/supabase/migrations/006_item_tags_entity_fk.sql
@@ -1,0 +1,7 @@
+-- 006: Add entity_id FK to item_tags
+-- Links company tags to canonical entities
+
+ALTER TABLE item_tags
+  ADD COLUMN entity_id uuid REFERENCES entities(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_item_tags_entity ON item_tags(entity_id) WHERE entity_id IS NOT NULL;

--- a/supabase/migrations/007_signals.sql
+++ b/supabase/migrations/007_signals.sql
@@ -1,0 +1,31 @@
+-- 007: Signals table
+-- The synthesis layer — LLM-extracted investment signals
+
+CREATE TABLE signals (
+  id                        uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  item_id                   uuid NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  signal_type               text NOT NULL CHECK (signal_type IN (
+                              'acquisition', 'fundraising', 'earnings',
+                              'layoffs', 'leadership', 'product_launch',
+                              'regulatory', 'platform_change', 'macro'
+                            )),
+  summary                   text NOT NULL,
+  investment_relevance_score float NOT NULL CHECK (
+                              investment_relevance_score >= 0
+                              AND investment_relevance_score <= 1
+                            ),
+  raw_llm_output            jsonb,
+  model_used                text,
+  created_at                timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_signals_item ON signals(item_id);
+CREATE INDEX idx_signals_type ON signals(signal_type);
+CREATE INDEX idx_signals_score ON signals(investment_relevance_score DESC);
+CREATE INDEX idx_signals_created ON signals(created_at DESC);
+
+-- RLS (match existing pattern — service role only)
+ALTER TABLE signals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON signals
+  FOR ALL USING (true) WITH CHECK (true);

--- a/supabase/migrations/008_api_keys.sql
+++ b/supabase/migrations/008_api_keys.sql
@@ -1,0 +1,22 @@
+-- 008: API keys table
+-- Multi-tenant API auth
+
+CREATE TABLE api_keys (
+  id              uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  key_hash        text NOT NULL UNIQUE,  -- sha256 of raw key; never store raw
+  label           text NOT NULL,         -- e.g. "hermanito", "wolo-agent"
+  owner           text NOT NULL,
+  scopes          jsonb NOT NULL DEFAULT '["items:read"]'::jsonb,
+  rate_limit_rpm  integer NOT NULL DEFAULT 60,
+  last_used_at    timestamptz,
+  created_at      timestamptz DEFAULT now(),
+  revoked_at      timestamptz            -- null = active; set to revoke, never delete
+);
+
+CREATE INDEX idx_api_keys_hash ON api_keys(key_hash);
+
+-- RLS (match existing pattern — service role only)
+ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON api_keys
+  FOR ALL USING (true) WITH CHECK (true);


### PR DESCRIPTION
## Summary

Implements the first major phase of the AST v1 refactor spec from Obsidian (`AST Implementation Spec — v1.md`).

## What's included

### Schema changes (migrations 004-008)
- **entities** table — replaces companies with type-aware model (company, person, game, event, org)
- **entity_aliases** table — deduplication layer for entity name resolution
- **signals** table — LLM-extracted investment signals with relevance scoring
- **api_keys** table — multi-tenant API auth (sha256 hashed keys, scopes, rate limits)
- **item_tags.entity_id** FK — links company tags to canonical entities

### Pipeline changes
- **Entity resolution** — company tags now resolve against entity_aliases at ingest time, entity_id set on item_tags
- **Signal gate** — fires if importance_score >= 0.4 + high-value category, OR entity resolved + has category
- **Signal extraction** — LLM call (gpt-4o-mini) extracts signal_type, summary, investment_relevance_score for items that pass gate
- **Non-blocking** — signal extraction wrapped in try/catch, never breaks ingestion

### Scripts
- **scripts/seed-entities.ts** — seeds entities + entity_aliases from existing GAMING_COMPANIES array

### Types
- Manually added signals table types and entity_id to item_tags in database.types.ts
- Marked with comments — will be replaced after migrations run + supabase gen types regen

## What's NOT included (per spec)
- Deletion of companies table / COMPANY_LIST in tagger (deferred until after migration + data verification)
- Drop of items.tags JSONB column (deferred until item_tags parity confirmed)
- New API endpoints (GET /api/v1/signals, GET /api/v1/entities) — Phase 2

## Next steps
1. Run migrations 004-008 in Supabase
2. Run `npx tsx scripts/seed-entities.ts` to populate entities + aliases
3. Regenerate types: `supabase gen types typescript --linked > src/lib/database.types.ts`
4. Remove manual type additions + TODO comments
5. Test signal extraction on a test ingest

## Notes
- Supabase client still typed as `any` in ingest.ts until types are regenerated (TODO comments added)
- Signal insert payload is typed against manually-added signals types for safety

Related: [[AST Implementation Spec — v1]]