### PR TITLE
fix: rename items→content, item_tags→content_tags, content→body

### DIFF
--- a/scripts/backfill-companies.ts
+++ b/scripts/backfill-companies.ts
@@ -28,8 +28,8 @@ async function backfill() {
 
   while (true) {
     const { data: items, error } = await supabase
-      .from("items")
-      .select("id, title, content, tags, source_id, sources(source_type)")
+      .from("content")
+      .select("id, title, body, tags, source_id, sources(source_type)")
       .range(offset, offset + PAGE_SIZE - 1)
       .order("published_at", { ascending: false, nullsFirst: false });
 
@@ -43,7 +43,7 @@ async function backfill() {
     for (const item of items) {
       total++;
       const sourceType = (item.sources as any)?.source_type || "news";
-      const result = tagItem(item.title, item.content, sourceType);
+      const result = tagItem(item.title, item.body, sourceType);
 
       if (result.company.length === 0) continue;
 
@@ -59,7 +59,7 @@ async function backfill() {
       };
 
       const { error: updateErr } = await supabase
-        .from("items")
+        .from("content")
         .update({ tags: updatedTags })
         .eq("id", item.id);
 
@@ -68,7 +68,7 @@ async function backfill() {
         continue;
       }
 
-      // Upsert into item_tags for filtering
+      // Upsert into content_tags for filtering
       const tagRows = mergedCompanies.map((c) => ({
         item_id: item.id,
         dimension: "company",
@@ -78,7 +78,7 @@ async function backfill() {
 
       if (tagRows.length > 0) {
         const { error: tagErr } = await supabase
-          .from("item_tags")
+          .from("content_tags")
           .upsert(tagRows, { onConflict: "item_id,dimension,value", ignoreDuplicates: true });
 
         if (tagErr) {
@@ -100,7 +100,7 @@ async function backfill() {
 
   // Show top companies
   const { data: topCompanies } = await supabase
-    .from("item_tags")
+    .from("content_tags")
     .select("value")
     .eq("dimension", "company");
 

--- a/scripts/backfill-tags.ts
+++ b/scripts/backfill-tags.ts
@@ -15,8 +15,8 @@ async function main() {
 
   // Get items with sources
   const { data: items, error } = await supabase
-    .from("items")
-    .select("id, title, content, source_id, sources(source_type)")
+    .from("content")
+    .select("id, title, body, source_id, sources(source_type)")
     .order("published_at", { ascending: false });
 
   if (error || !items) {
@@ -31,8 +31,8 @@ async function main() {
 
   for (const item of items) {
     const sourceType = (item as any).sources?.source_type || "news";
-    const ruleTags = tagItem(item.title, item.content, sourceType);
-    const aiTags = await tagItemWithAI(item.title, item.content);
+    const ruleTags = tagItem(item.title, item.body, sourceType);
+    const aiTags = await tagItemWithAI(item.title, item.body);
 
     const allTags = {
       category: ruleTags.category,
@@ -43,11 +43,11 @@ async function main() {
 
     // Update items.tags jsonb
     await supabase
-      .from("items")
+      .from("content")
       .update({ tags: allTags })
       .eq("id", item.id);
 
-    // Upsert into item_tags
+    // Upsert into content_tags
     const tagRows: { item_id: string; dimension: string; value: string; manual: boolean }[] = [];
     for (const [dimension, values] of Object.entries(allTags)) {
       for (const value of values) {
@@ -56,7 +56,7 @@ async function main() {
     }
     if (tagRows.length > 0) {
       await supabase
-        .from("item_tags")
+        .from("content_tags")
         .upsert(tagRows, { onConflict: "item_id,dimension,value", ignoreDuplicates: true });
       tagCount += tagRows.length;
     }

--- a/scripts/extract-signals.ts
+++ b/scripts/extract-signals.ts
@@ -67,7 +67,7 @@ const VALID_SIGNAL_TYPES = new Set([
 async function getEligibleItems(): Promise<EligibleItem[]> {
   // Get items that don't have signals yet
   const { data: items, error } = await supabase
-    .from("items")
+    .from("content")
     .select(`
       id,
       title,
@@ -105,7 +105,7 @@ async function getEligibleItems(): Promise<EligibleItem[]> {
   // Fetch tags for all unprocessed items in a single query (fix N+1)
   const unprocessedItemIds = unprocessedItems.map((i: any) => i.id);
   const { data: allTags } = await supabase
-    .from("item_tags")
+    .from("content_tags")
     .select("item_id, dimension, value")
     .in("item_id", unprocessedItemIds);
 
@@ -128,7 +128,7 @@ async function getEligibleItems(): Promise<EligibleItem[]> {
       id: item.id,
       title: item.title,
       url: item.url,
-      content: item.content,
+      content: item.body,
       published_at: item.published_at,
       companies,
       categories,
@@ -148,7 +148,7 @@ function shouldExtractSignal(item: EligibleItem): boolean {
   }
 
   // Skip if content is null or too short
-  if (!item.content || item.content.length < 100) {
+  if (!item.body || item.body.length < 100) {
     return false;
   }
 
@@ -168,7 +168,7 @@ COMPANIES MENTIONED: ${item.companies.join(", ") || "none"}
 CATEGORIES: ${item.categories.join(", ") || "none"}
 
 CONTENT:
-${item.content}
+${item.body}
 
 ---
 

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
   const supabase = createServerClient();
 
   const { data, error } = await supabase
-    .from("item_tags")
+    .from("content_tags")
     .select("value")
     .eq("dimension", "company") as { data: { value: string }[] | null; error: any };
 

--- a/src/app/api/feed.xml/route.ts
+++ b/src/app/api/feed.xml/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
   const supabase = createServerClient();
 
   const { data, error } = (await supabase
-    .from("items")
+    .from("content")
     .select("*, sources!inner(name, url, source_type, active)")
     .eq("sources.active" as string, true)
     .order("published_at", { ascending: false, nullsFirst: false })
@@ -41,8 +41,8 @@ export async function GET() {
       const sourceName = source?.name ?? "Unknown";
       const title = item.title ? escapeXml(item.title) : "Untitled";
       const link = item.url ? escapeXml(item.url) : "";
-      const description = item.content
-        ? escapeXml(truncate(item.content, 500))
+      const description = item.body
+        ? escapeXml(truncate(item.body, 500))
         : "";
       const pubDate = item.published_at
         ? new Date(item.published_at).toUTCString()

--- a/src/app/api/items/route.ts
+++ b/src/app/api/items/route.ts
@@ -24,7 +24,7 @@ export async function GET(req: NextRequest) {
   const supabase = createServerClient();
 
   let query = supabase
-    .from("items")
+    .from("content")
     .select("*, sources!inner(name, url, source_type, active)", { count: "exact" })
     .eq("sources.active", true)
     .order("published_at", { ascending: false, nullsFirst: false });

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -38,7 +38,7 @@ export async function GET() {
 
   // Get article counts per source
   const { data: countData } = await supabase
-    .from("items")
+    .from("content")
     .select("source_id") as { data: { source_id: string | null }[] | null; error: any };
 
   const articleCounts: Record<string, number> = {};
@@ -50,7 +50,7 @@ export async function GET() {
 
   // Get latest article date per source
   const { data: latestData } = await supabase
-    .from("items")
+    .from("content")
     .select("source_id, published_at")
     .order("published_at", { ascending: false, nullsFirst: false }) as {
     data: { source_id: string | null; published_at: string | null }[] | null;
@@ -140,7 +140,7 @@ export async function DELETE(req: NextRequest) {
 
   // Delete related items first (foreign key constraint)
   const { error: itemsError } = await supabase
-    .from("items")
+    .from("content")
     .delete()
     .eq("source_id", id);
 

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
 
   // Get all unique tags grouped by dimension
   const { data, error } = await supabase
-    .from("item_tags")
+    .from("content_tags")
     .select("dimension, value") as { data: { dimension: string; value: string }[] | null; error: any };
 
   if (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ async function getItems(): Promise<{ items: FeedItem[]; hasMore: boolean }> {
 
   const supabase = createServerClient();
   const { data, error } = await supabase
-    .from("items")
+    .from("content")
     .select("*, sources!inner(name, url, source_type, active)")
     .eq("sources.active", true)
     .order("published_at", { ascending: false, nullsFirst: false })

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -108,7 +108,7 @@ export function matchesFilter(item: FeedItem, filters: FilterState): boolean {
     const q = filters.search.toLowerCase();
     checks.push(
       item.title.toLowerCase().includes(q) ||
-        (item.content || "").toLowerCase().includes(q)
+        (item.body || "").toLowerCase().includes(q)
     );
   }
 

--- a/src/components/FeedRow.tsx
+++ b/src/components/FeedRow.tsx
@@ -109,7 +109,7 @@ export function FeedRow({ item }: FeedRowProps) {
   
   const sourceType = item.sources?.source_type || "news";
   const borderColor = SOURCE_COLORS[sourceType] || "border-l-ast-accent";
-  const fullContent = cleanContent(item.content);
+  const fullContent = cleanContent(item.body);
   const hasMoreContent = fullContent.length > 180;
   const faviconUrl = getFaviconUrl(item.sources?.url);
 
@@ -167,9 +167,9 @@ export function FeedRow({ item }: FeedRowProps) {
             <h3 className="text-ast-text text-sm font-medium leading-snug group-hover:text-ast-accent transition-colors">
               {item.title}
             </h3>
-            {item.content && !expanded && (
+            {item.body && !expanded && (
               <p className="text-ast-muted text-xs mt-1 leading-relaxed hidden sm:block">
-                {truncate(item.content, 180)}
+                {truncate(item.body, 180)}
               </p>
             )}
             <TagChips tags={item.tags as Record<string, string[]> | null} />

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -56,39 +56,45 @@ export interface Database {
           source_id: string | null;
           external_id: string | null;
           title: string;
-          content: string | null;
+          body: string | null;
           url: string;
           author: string | null;
           published_at: string | null;
           ingested_at: string;
           tags: Json;
+          content_type: string;
+          signals_extracted_at: string | null;
         };
         Insert: {
           id?: string;
           source_id?: string | null;
           external_id?: string | null;
           title: string;
-          content?: string | null;
+          body?: string | null;
           url: string;
           author?: string | null;
           published_at?: string | null;
           ingested_at?: string;
           tags?: Json;
+          content_type?: string;
+          signals_extracted_at?: string | null;
         };
         Update: {
           id?: string;
           source_id?: string | null;
           external_id?: string | null;
           title?: string;
-          content?: string | null;
+          body?: string | null;
           url?: string;
           author?: string | null;
           published_at?: string | null;
           ingested_at?: string;
           tags?: Json;
+          content_type?: string;
+          signals_extracted_at?: string | null;
         };
       };
-      item_tags: {
+      content_tags: {
         Row: {
           id: string;
           item_id: string;
@@ -96,7 +102,7 @@ export interface Database {
           value: string;
           confidence: number | null;
           manual: boolean;
-          entity_id: string | null; // MANUALLY ADDED — pending migration 006_item_tags_entity_fk.sql
+          entity_id: string | null; // MANUALLY ADDED — pending migration 006_content_tags_entity_fk.sql
         };
         Insert: {
           id?: string;
@@ -105,7 +111,7 @@ export interface Database {
           value: string;
           confidence?: number | null;
           manual?: boolean;
-          entity_id?: string | null; // MANUALLY ADDED — pending migration 006_item_tags_entity_fk.sql
+          entity_id?: string | null; // MANUALLY ADDED — pending migration 006_content_tags_entity_fk.sql
         };
         Update: {
           id?: string;
@@ -114,7 +120,7 @@ export interface Database {
           value?: string;
           confidence?: number | null;
           manual?: boolean;
-          entity_id?: string | null; // MANUALLY ADDED — pending migration 006_item_tags_entity_fk.sql
+          entity_id?: string | null; // MANUALLY ADDED — pending migration 006_content_tags_entity_fk.sql
         };
       };
       companies: {
@@ -216,8 +222,8 @@ export interface Database {
 
 // Convenience types
 export type Source = Database["public"]["Tables"]["sources"]["Row"];
-export type Item = Database["public"]["Tables"]["items"]["Row"];
-export type ItemTag = Database["public"]["Tables"]["item_tags"]["Row"];
+export type Item = Database["public"]["Tables"]["content"]["Row"];
+export type ItemTag = Database["public"]["Tables"]["content_tags"]["Row"];
 export type Company = Database["public"]["Tables"]["companies"]["Row"];
 export type IngestionLog = Database["public"]["Tables"]["ingestion_logs"]["Row"];
 export type Signal = Database["public"]["Tables"]["signals"]["Row"];

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -97,7 +97,7 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
       source_id: source.id,
       external_id: item.guid || item.link || item.title || "",
       title: item.title || "(no title)",
-      content: item.contentSnippet || item.content || null,
+      body: item.bodySnippet || item.body || null,
       url: item.link || source.url,
       author: item.creator || item.author || null,
       published_at: item.isoDate || null,
@@ -106,9 +106,9 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
 
     // Upsert — on conflict (source_id, external_id) do nothing
     const { data, error } = await supabase
-      .from("items")
+      .from("content")
       .upsert(rows, { onConflict: "source_id,external_id", ignoreDuplicates: true })
-      .select("id, title, content");
+      .select("id, title, body");
 
     if (error) {
       result.errors.push(`DB: ${error.message}`);
@@ -118,9 +118,9 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
       // Tag newly inserted items (batched for performance)
       if (data?.length) {
         // Step 1: Compute all tags in parallel (AI calls run concurrently)
-        const tagPromises = data.map(async (item: { id: string; title: string; content: string | null }) => {
-          const ruleTags = tagItem(item.title, item.content, source.source_type);
-          const aiTags = await tagItemWithAI(item.title, item.content);
+        const tagPromises = data.map(async (item: { id: string; title: string; body: string | null }) => {
+          const ruleTags = tagItem(item.title, item.body, source.source_type);
+          const aiTags = await tagItemWithAI(item.title, item.body);
           return {
             id: item.id,
             tags: {
@@ -136,11 +136,11 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
         // Step 2: Batch update items.tags (parallel DB writes)
         await Promise.all(
           itemsWithTags.map(({ id, tags }) =>
-            supabase.from("items").update({ tags }).eq("id", id)
+            supabase.from("content").update({ tags }).eq("id", id)
           )
         );
 
-        // Step 3: Collect all item_tags rows for single batch upsert
+        // Step 3: Collect all content_tags rows for single batch upsert
         const allTagRows: { item_id: string; dimension: string; value: string; manual: boolean }[] = [];
         for (const { id, tags } of itemsWithTags) {
           for (const [dimension, values] of Object.entries(tags) as [string, string[]][]) {
@@ -151,7 +151,7 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
         }
         if (allTagRows.length > 0) {
           await supabase
-            .from("item_tags")
+            .from("content_tags")
             .upsert(allTagRows, { onConflict: "item_id,dimension,value", ignoreDuplicates: true });
         }
 
@@ -176,12 +176,12 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
                 // Build a map of alias -> entity_id
                 const aliasMap = new Map(aliases.map((a: { alias: string; entity_id: string }) => [a.alias.toLowerCase(), a.entity_id]));
 
-                // Update item_tags rows with entity_id
+                // Update content_tags rows with entity_id
                 for (const company of companyTags) {
                   const entityId = aliasMap.get(company.toLowerCase());
                   if (entityId) {
                     await supabase
-                      .from("item_tags")
+                      .from("content_tags")
                       .update({ entity_id: entityId })
                       .eq("item_id", id)
                       .eq("dimension", "company")
@@ -195,7 +195,7 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
             const itemForSignal = {
               id,
               title: data.find((d: { id: string }) => d.id === id)?.title || "",
-              content: data.find((d: { id: string }) => d.id === id)?.content || null,
+              body: data.find((d: { id: string }) => d.id === id)?.body || null,
               tags,
               sources: { source_type: source.source_type },
             };

--- a/src/lib/signal-extractor.ts
+++ b/src/lib/signal-extractor.ts
@@ -188,7 +188,7 @@ export async function extractSignal(options: ExtractSignalOptions): Promise<void
     }
 
     // Extract signal via LLM
-    const signal = await extractSignalWithLLM(item.title, item.content);
+    const signal = await extractSignalWithLLM(item.title, item.body);
     if (!signal) {
       // LLM failed or timed out — log but don't break ingestion
       console.warn(`[signal-extractor] Failed to extract signal for item ${item.id}`);


### PR DESCRIPTION
Aligns all DB references with the table renames done in Supabase this session.

**Changes:**
- `from("items")` → `from("content")` across all src/ and scripts/
- `from("item_tags")` → `from("content_tags")`
- `item.content` → `item.body` (column rename)
- `database.types.ts` updated: content table Row/Insert/Update reflects `body`, adds `content_type` and `signals_extracted_at`

No logic changes — pure rename.