### PR TITLE
feat: add vercel.json cron for automated hourly ingestion

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/ingest",
-      "schedule": "0 8 * * *"
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `vercel.json` with hourly cron config so the feed auto-updates without manual triggers.

## Changes
- `vercel.json`: cron schedule `0 * * * *` (hourly) hitting `/api/ingest`
- Verified `CRON_SECRET` auth check already exists in the ingest handler (lines 7-18)

## Done
- Feed auto-ingests hourly via Vercel cron
- `CRON_SECRET` auth check confirmed present
- `tsc --noEmit` clean

Closes #8