### PR TITLE
feat: Supabase Auth + email sign-in + invite gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "always-scheming-terminal",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.45.0",
         "dotenv": "^17.2.3",
         "next": "^15.1.0",
@@ -1805,9 +1806,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.100.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
-      "integrity": "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.1.tgz",
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1817,9 +1818,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.100.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.1.tgz",
-      "integrity": "sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.1.tgz",
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1829,15 +1830,15 @@
       }
     },
     "node_modules/@supabase/phoenix": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
-      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.100.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.1.tgz",
-      "integrity": "sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.1.tgz",
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1847,24 +1848,34 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.100.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.1.tgz",
-      "integrity": "sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.1.tgz",
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/phoenix": "^0.4.0",
-        "@types/ws": "^8.18.1",
-        "tslib": "2.8.1",
-        "ws": "^8.18.2"
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/ssr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.0.tgz",
+      "integrity": "sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.108.0"
+      }
+    },
     "node_modules/@supabase/storage-js": {
-      "version": "2.100.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.1.tgz",
-      "integrity": "sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.1.tgz",
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -1875,16 +1886,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.100.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
-      "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.1.tgz",
+      "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.100.1",
-        "@supabase/functions-js": "2.100.1",
-        "@supabase/postgrest-js": "2.100.1",
-        "@supabase/realtime-js": "2.100.1",
-        "@supabase/storage-js": "2.100.1"
+        "@supabase/auth-js": "2.108.1",
+        "@supabase/functions-js": "2.108.1",
+        "@supabase/postgrest-js": "2.108.1",
+        "@supabase/realtime-js": "2.108.1",
+        "@supabase/storage-js": "2.108.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1966,15 +1977,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
@@ -3156,6 +3158,19 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js": {
       "version": "3.49.0",
@@ -7505,27 +7520,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "extract-signals": "npx tsx scripts/extract-signals.ts"
   },
   "dependencies": {
+    "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.45.0",
     "dotenv": "^17.2.3",
     "next": "^15.1.0",

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState } from "react";
+import { createAuthBrowserClient } from "@/lib/supabase";
+import { useRouter } from "next/navigation";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [inviteCode, setInviteCode] = useState("");
+  const [isSignUp, setIsSignUp] = useState(false);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const supabase = createAuthBrowserClient();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      if (isSignUp) {
+        // Validate invite code on signup
+        const requiredCode = process.env.NEXT_PUBLIC_BETA_INVITE_CODE;
+        if (!requiredCode) {
+          setError("Beta invites are not configured");
+          setLoading(false);
+          return;
+        }
+
+        if (inviteCode !== requiredCode) {
+          setError("Invalid invite code");
+          setLoading(false);
+          return;
+        }
+
+        const { error: signUpError } = await supabase.auth.signUp({
+          email,
+          password,
+        });
+
+        if (signUpError) throw signUpError;
+
+        // Show success message
+        setError("Check your email to confirm your account!");
+      } else {
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
+
+        if (signInError) throw signInError;
+
+        // Redirect to home
+        router.push("/");
+        router.refresh();
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0a0e27] flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-white mb-2">
+            Always Scheming Terminal
+          </h1>
+          <p className="text-gray-400">
+            {isSignUp ? "Create your account" : "Sign in to continue"}
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-[#1a1f3a] rounded-lg p-8 space-y-6"
+        >
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-300 mb-2"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-4 py-2 bg-[#0a0e27] border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-300 mb-2"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={6}
+              className="w-full px-4 py-2 bg-[#0a0e27] border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {isSignUp && (
+            <div>
+              <label
+                htmlFor="inviteCode"
+                className="block text-sm font-medium text-gray-300 mb-2"
+              >
+                Invite Code
+              </label>
+              <input
+                id="inviteCode"
+                type="text"
+                value={inviteCode}
+                onChange={(e) => setInviteCode(e.target.value)}
+                required
+                className="w-full px-4 py-2 bg-[#0a0e27] border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          )}
+
+          {error && (
+            <div className="text-red-400 text-sm bg-red-900/20 border border-red-800 rounded-md p-3">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium py-2 px-4 rounded-md transition-colors"
+          >
+            {loading ? "Loading..." : isSignUp ? "Sign Up" : "Sign In"}
+          </button>
+
+          <div className="text-center">
+            <button
+              type="button"
+              onClick={() => {
+                setIsSignUp(!isSignUp);
+                setError("");
+                setInviteCode("");
+              }}
+              className="text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              {isSignUp
+                ? "Already have an account? Sign in"
+                : "Need an account? Sign up"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,8 +3,10 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { ShortcutsHelp } from "./ShortcutsHelp";
 import { useTheme } from "./ThemeProvider";
+import { createAuthBrowserClient } from "@/lib/supabase";
 
 function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -57,6 +59,15 @@ function ThemeToggle() {
 }
 
 export function Header() {
+  const router = useRouter();
+  const supabase = createAuthBrowserClient();
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    router.push("/auth/login");
+    router.refresh();
+  };
+
   return (
     <header className="h-12 sm:h-14 border-b border-ast-border sticky top-0 z-50 bg-ast-bg/95 backdrop-blur-sm">
       <div className="h-full max-w-5xl mx-auto px-3 sm:px-4 flex items-center justify-between">
@@ -98,6 +109,13 @@ export function Header() {
           >
             ⚙ Admin
           </Link>
+          <button
+            onClick={handleSignOut}
+            className="text-ast-muted hover:text-red-400 text-xs transition-colors"
+            title="Sign out"
+          >
+            Sign out
+          </button>
           <span className="text-ast-muted text-[10px] sm:text-xs">v0.1</span>
         </div>
       </div>

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,0 +1,30 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import type { Database } from "./database.types";
+
+export async function createAuthServerClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            // The `setAll` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+      },
+    }
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { createBrowserClient as createBrowserClientSSR } from "@supabase/ssr";
 import type { Database } from "./database.types";
 
 // Client-side Supabase client (uses anon key, respects RLS)
@@ -15,5 +16,13 @@ export function createServerClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     { auth: { persistSession: false } }
+  );
+}
+
+// SSR-compatible browser client for auth (with cookie handling)
+export function createAuthBrowserClient() {
+  return createBrowserClientSSR<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,72 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
 
-// Auth has been moved to individual route handlers (src/lib/api-auth.ts)
-// because Next.js middleware always runs on Edge Runtime and supabase-js
-// requires Node.js. Route handlers export `runtime = "nodejs"` and do
-// the key check there instead.
-export function middleware(request: NextRequest) {
-  return NextResponse.next();
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Skip middleware for API routes (they have their own auth via api-auth.ts)
+  if (pathname.startsWith("/api/")) {
+    return NextResponse.next();
+  }
+
+  let supabaseResponse = NextResponse.next({
+    request,
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({
+            request,
+          });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  // Refresh session if expired - required for Server Components
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Protected routes: everything except /auth/*
+  if (!pathname.startsWith("/auth/") && !user) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/auth/login";
+    return NextResponse.redirect(url);
+  }
+
+  // If user is logged in and trying to access /auth/login, redirect to home
+  if (pathname === "/auth/login" && user) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
 }
 
 export const config = {
-  matcher: "/api/v1/:path*",
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - public folder files
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "scripts"
   ]
 }


### PR DESCRIPTION
Phase 4-A: Auth gate on terminal UI.

- @supabase/ssr (not deprecated auth-helpers)
- /auth/login page with email/password sign-in + sign-up
- Terminal feed (/) gated — unauthenticated redirected to /auth/login
- Invite code gate on signup via NEXT_PUBLIC_BETA_INVITE_CODE env var
- Sign-out button in header
- Middleware handles auth session refresh + route protection
- API v1 routes unaffected (still api-key auth)
- Build passes clean