### PR TITLE
fix: signals API join content table (not items)

### DIFF
--- a/src/app/api/v1/signals/route.ts
+++ b/src/app/api/v1/signals/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
       summary,
       investment_relevance_score,
       created_at,
-      items (id, title, url, published_at)
+      content (id, title, url, published_at)
     `)
     .order("created_at", { ascending: false })
     .limit(limit);


### PR DESCRIPTION
## Problem
`/api/v1/signals` was doing a PostgREST join on `items` — the old table name. The table was renamed to `content` in PR #15, but the signals route was never updated.

**Error:** `Could not find a relationship between 'signals' and 'items' in the schema cache`

## Fix
One line: `items (id, title, url, published_at)` → `content (id, title, url, published_at)` in the Supabase select query.

## Test
```bash
curl "https://terminal.always-scheming.fyi/api/v1/signals?limit=3" \
  -H "Authorization: Bearer ast_6c3732f0c3405ff36eeddcbc68af3f3e4593c9dd011f6419"
```
Should return signal data instead of 500.