### PR TITLE
feat: PostHog user identification

### DIFF
--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -2,6 +2,7 @@
 
 import posthog from 'posthog-js';
 import { useEffect } from 'react';
+import { createAuthBrowserClient } from '@/lib/supabase';
 
 // iOS Navigator extension for standalone detection
 interface IOSNavigator extends Navigator {
@@ -48,6 +49,16 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         posthog.capture('pwa_launched');
         sessionStorage.setItem('pwa_launch_tracked', 'true');
       }
+
+      // Identify authenticated user so events are tied to a person profile
+      const supabase = createAuthBrowserClient();
+      supabase.auth.getSession().then(({ data: { session } }) => {
+        if (session?.user) {
+          posthog.identify(session.user.id, {
+            email: session.user.email,
+          });
+        }
+      });
     }
   }, []);
 


### PR DESCRIPTION
## What
Calls `posthog.identify(user.id, { email })` after Supabase session resolves on mount.

## Why
`person_profiles: 'identified_only'` was already set — meaning PostHog only creates person profiles when `identify()` is called. Without this, all events were anonymous UUIDs with no way to tell users apart in the dashboard.

## Behavior
- On page load, reads the active Supabase session via `createAuthBrowserClient()`
- If a session exists, calls `posthog.identify(user.id)` with email as a person property
- Unauthenticated sessions (pre-login page) remain anonymous — no identify call fires
- All prior anonymous events for the session are automatically merged into the identified profile by PostHog

## No changes to
- Auth flow, middleware, API routes, or any other component