### PR TITLE
fix: entity resolver now syncs company tags to content.tags JSONB

### DIFF
--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -237,6 +237,25 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
                 }, { onConflict: "item_id,dimension,value", ignoreDuplicates: false });
             }
 
+            // Also update content.tags JSONB so chips appear in UI
+            if (resolvedEntities.length > 0) {
+              const resolvedCompanyNames = resolvedEntities
+                .filter(e => e.entity_type === 'company')
+                .map(e => e.canonical_name);
+              
+              if (resolvedCompanyNames.length > 0) {
+                const currentTags = tags as Record<string, string[]>;
+                const mergedCompanies = [...new Set([
+                  ...(currentTags.company || []),
+                  ...resolvedCompanyNames
+                ])];
+                await supabase
+                  .from('content')
+                  .update({ tags: { ...currentTags, company: mergedCompanies } })
+                  .eq('id', id);
+              }
+            }
+
             // Try signal extraction (non-blocking, errors logged internally)
             const itemForSignal = {
               id,


### PR DESCRIPTION
## Summary\n\nEntity resolver was writing resolved companies to `content_tags` rows but never updating `content.tags.company` JSONB. Feed UI reads from that JSONB (LiveFeed.tsx), so chips never appeared.\n\n## Fix\n\nAfter entity resolution in `src/lib/ingest.ts`, resolved company canonical names are now merged into `content.tags.company` with a `content` table update. Both writes are preserved: `content_tags` (for entity_id FK) and `content.tags` (for UI).\n\n## Changed files\n- `src/lib/ingest.ts` (lines 241-257)\n\n## Verification\n- `tsc --noEmit` passes\n- After ingest, articles about Xbox/Microsoft/EA etc will show company chips in the feed