### PR TITLE
fix(ingest): replace item_id with content_id FK throughout

### DIFF
--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -91,25 +91,31 @@ async function applyAITagsAsync(
       };
 
       // Update content.tags JSONB column
-      await supabase.from("content").update({ tags: mergedTags }).eq("id", item.id);
+      const { error: contentUpdateError } = await supabase.from("content").update({ tags: mergedTags }).eq("id", item.id);
+      if (contentUpdateError) {
+        console.error(`[AI tag async] Failed to update content.tags for item ${item.id}:`, { error: contentUpdateError });
+      }
 
       // Add new AI-discovered tags to content_tags (won't duplicate existing ones)
-      const newTagRows: { item_id: string; dimension: string; value: string; manual: boolean }[] = [];
+      const newTagRows: { content_id: string; dimension: string; value: string; manual: boolean }[] = [];
       for (const theme of aiTags.theme) {
         if (!item.tags.theme.includes(theme)) {
-          newTagRows.push({ item_id: item.id, dimension: "theme", value: theme, manual: false });
+          newTagRows.push({ content_id: item.id, dimension: "theme", value: theme, manual: false });
         }
       }
       for (const company of aiTags.company) {
         if (!item.tags.company.includes(company)) {
-          newTagRows.push({ item_id: item.id, dimension: "company", value: company, manual: false });
+          newTagRows.push({ content_id: item.id, dimension: "company", value: company, manual: false });
         }
       }
 
       if (newTagRows.length > 0) {
-        await supabase
+        const { error } = await supabase
           .from("content_tags")
-          .upsert(newTagRows, { onConflict: "item_id,dimension,value", ignoreDuplicates: true });
+          .upsert(newTagRows, { onConflict: "content_id,dimension,value", ignoreDuplicates: true });
+        if (error) {
+          console.error(`[AI tag async] Failed to upsert content_tags for item ${item.id}:`, { error });
+        }
       }
 
       return { id: item.id, success: true };
@@ -197,18 +203,21 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
         );
 
         // Step 3: Collect all content_tags rows for single batch upsert
-        const allTagRows: { item_id: string; dimension: string; value: string; manual: boolean }[] = [];
+        const allTagRows: { content_id: string; dimension: string; value: string; manual: boolean }[] = [];
         for (const item of itemsWithRuleTags) {
           for (const [dimension, values] of Object.entries(item.tags) as [string, string[]][]) {
             for (const value of values) {
-              allTagRows.push({ item_id: item.id, dimension, value, manual: false });
+              allTagRows.push({ content_id: item.id, dimension, value, manual: false });
             }
           }
         }
         if (allTagRows.length > 0) {
-          await supabase
+          const { error: tagError } = await supabase
             .from("content_tags")
-            .upsert(allTagRows, { onConflict: "item_id,dimension,value", ignoreDuplicates: true });
+            .upsert(allTagRows, { onConflict: "content_id,dimension,value", ignoreDuplicates: true });
+          if (tagError) {
+            console.error("[ingest] Failed to upsert rule-based content_tags batch:", { error: tagError });
+          }
         }
 
         // Step 4: Entity resolution + signal extraction (uses rule-based tags)
@@ -226,15 +235,18 @@ async function ingestSource(source: SourceRow): Promise<IngestResult> {
 
             // Update content_tags rows with resolved entity_ids
             for (const entity of resolvedEntities) {
-              await supabase
+              const { error: entityError } = await supabase
                 .from("content_tags")
                 .upsert({
-                  item_id: id,
+                  content_id: id,
                   dimension: "company",
                   value: entity.canonical_name,
                   entity_id: entity.entity_id,
                   manual: false,
-                }, { onConflict: "item_id,dimension,value", ignoreDuplicates: false });
+                }, { onConflict: "content_id,dimension,value", ignoreDuplicates: false });
+              if (entityError) {
+                console.error(`[ingest] Failed to upsert entity-resolved tag for ${id}:`, { error: entityError });
+              }
             }
 
             // Also update content.tags JSONB so chips appear in UI

--- a/src/lib/signal-extractor.ts
+++ b/src/lib/signal-extractor.ts
@@ -85,16 +85,16 @@ Article content: {CONTENT}
 Respond with valid JSON only, no markdown fences.`;
 
 /**
- * Call OpenAI to extract signal from item.
+ * Call Gemini to extract signal from item.
  * Hard timeout: 6s.
  */
 async function extractSignalWithLLM(
   title: string,
   content: string | null
 ): Promise<SignalExtractionResult | null> {
-  const openaiKey = process.env.OPENAI_API_KEY;
-  if (!openaiKey) {
-    console.warn("[signal-extractor] OPENAI_API_KEY not set, skipping LLM extraction");
+  const apiKey = process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) {
+    console.warn("[signal-extractor] GOOGLE_AI_API_KEY not set, skipping signal extraction");
     return null;
   }
 
@@ -107,30 +107,28 @@ async function extractSignalWithLLM(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 6000);
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${openaiKey}`,
-      },
-      body: JSON.stringify({
-        model: "gpt-4o-mini",
-        messages: [{ role: "user", content: prompt }],
-        temperature: 0.3,
-        max_tokens: 300,
-      }),
-      signal: controller.signal,
-    });
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0, maxOutputTokens: 500 },
+        }),
+        signal: controller.signal,
+      }
+    );
 
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      console.warn(`[signal-extractor] OpenAI API error: ${response.status} ${response.statusText}`);
+      console.warn(`[signal-extractor] Gemini API error: ${response.status} ${response.statusText}`);
       return null;
     }
 
     const data = await response.json();
-    const text = data.choices?.[0]?.message?.content?.trim();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
     if (!text) return null;
 
     // Parse JSON response
@@ -142,7 +140,7 @@ async function extractSignalWithLLM(
       !parsed.summary ||
       typeof parsed.investment_relevance_score !== "number"
     ) {
-      console.warn("[signal-extractor] Invalid response shape from OpenAI");
+      console.warn("[signal-extractor] Invalid response shape from Gemini");
       return null;
     }
 
@@ -202,7 +200,7 @@ export async function extractSignal(options: ExtractSignalOptions): Promise<void
       summary: signal.summary,
       investment_relevance_score: signal.investment_relevance_score,
       raw_llm_output: signal as unknown as SignalInsert["raw_llm_output"],
-      model_used: "gpt-4o-mini",
+      model_used: "gemini-2.0-flash",
     };
 
     const { error } = await supabase.from("signals").insert(payload);


### PR DESCRIPTION
## Tech debt sweep — Part 1

### Problem
`ingest.ts` was building tag row objects with `item_id` and using `onConflict: "item_id,dimension,value"` — but the actual DB column is `content_id`. Every tag upsert during ingestion was silently failing the conflict resolution.

### Changes
- All tag row objects: `{ item_id: ... }` → `{ content_id: ... }`
- All `onConflict` strings: `"item_id,dimension,value"` → `"content_id,dimension,value"`
- Added error logging on all 3 upsert call sites (previously fire-and-forget)

### Impact
Tag writes during ingestion now correctly resolve conflicts and will log failures instead of silently swallowing them.