### PR TITLE
fix: profile UX — back button, segment explainers, interests dropdown

### DIFF
--- a/src/app/api/tags/themes/route.ts
+++ b/src/app/api/tags/themes/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { createAuthServerClient } from "@/lib/supabase-server";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const supabase = await createAuthServerClient();
+
+  // Get the authenticated user
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError || !session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Query distinct theme values
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from("content_tags")
+    .select("value")
+    .eq("dimension", "theme")
+    .order("value", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch themes" },
+      { status: 500 }
+    );
+  }
+
+  // Extract unique values
+  const themes = Array.from(new Set(data.map((row: { value: string }) => row.value)));
+
+  return NextResponse.json({ themes });
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -7,14 +7,14 @@ import { Profile, UserPreferences } from "@/lib/database.types";
 
 // 9 segments from company-list-v1.md
 const SEGMENTS = [
-  "Platform Holders & Big Tech",
-  "Major Western Publishers",
-  "Major Asian Publishers",
-  "Mobile-First / F2P Specialists",
-  "PC/Console Studios & Indies",
-  "Mid-Market / European Publishers",
-  "Infrastructure / Middleware / Services",
-  "Investment / Holding / Corporate",
+  { name: 'Platform Holders & Big Tech', description: 'Microsoft (Xbox), Sony (PlayStation), Nintendo, Apple, Google, Meta, Valve, Epic, Roblox' },
+  { name: 'Major Western Publishers', description: 'EA, Take-Two, Ubisoft, Embracer, CD Projekt, Devolver' },
+  { name: 'Major Asian Publishers', description: 'Tencent, NetEase, Nexon, Krafton, Bandai Namco, Capcom, Square Enix, Sega, miHoYo, Sea Limited' },
+  { name: 'Mobile-First / F2P Specialists', description: 'Supercell, AppLovin, Scopely, Dream Games, Niantic, Voodoo' },
+  { name: 'PC/Console Studios & Indies', description: 'Larian, Annapurna, Riot, FromSoftware, Activision Blizzard, Bethesda, Bungie' },
+  { name: 'Mid-Market / European Publishers', description: 'Paradox, Keywords Studios, Team17, Warner Bros Games, Frontier, Embracer labels' },
+  { name: 'Infrastructure / Middleware / Services', description: 'Unity, Discord, Xsolla, Overwolf, ironSource, Twitch' },
+  { name: 'Investment / Holding / Corporate', description: 'Savvy Games Group, Kadokawa, tencent holding stakes, private equity' },
 ];
 
 export default function ProfilePage() {
@@ -32,6 +32,7 @@ export default function ProfilePage() {
   const [interests, setInterests] = useState<string[]>([]);
   const [segments, setSegments] = useState<string[]>([]);
   const [interestInput, setInterestInput] = useState("");
+  const [availableThemes, setAvailableThemes] = useState<string[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -53,6 +54,13 @@ export default function ProfilePage() {
           setDisplayName(data.profile.display_name || "");
           setInterests(data.preferences.interests || []);
           setSegments(data.preferences.segments || []);
+        }
+
+        // Fetch available themes
+        const themesResponse = await fetch("/api/tags/themes");
+        if (themesResponse.ok) {
+          const themesData = await themesResponse.json();
+          setAvailableThemes(themesData.themes || []);
         }
       } catch (err) {
         console.error("Failed to fetch profile", err);
@@ -126,10 +134,10 @@ export default function ProfilePage() {
     }
   };
 
-  const handleToggleSegment = async (segment: string) => {
-    const newSegments = segments.includes(segment)
-      ? segments.filter((s) => s !== segment)
-      : [...segments, segment];
+  const handleToggleSegment = async (segmentName: string) => {
+    const newSegments = segments.includes(segmentName)
+      ? segments.filter((s) => s !== segmentName)
+      : [...segments, segmentName];
     
     setSegments(newSegments);
 
@@ -160,6 +168,15 @@ export default function ProfilePage() {
   return (
     <div className="min-h-screen bg-ast-bg">
       <div className="max-w-3xl mx-auto px-4 py-8">
+        <button
+          onClick={() => router.push("/")}
+          className="flex items-center gap-2 text-ast-muted hover:text-ast-text mb-6 transition-colors"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to Terminal
+        </button>
         <h1 className="text-2xl font-bold text-ast-text mb-6">Profile Settings</h1>
 
         <div className="space-y-6">
@@ -228,8 +245,14 @@ export default function ProfilePage() {
                 onChange={(e) => setInterestInput(e.target.value)}
                 onKeyPress={(e) => e.key === "Enter" && handleAddInterest()}
                 placeholder="Add an interest"
+                list="theme-suggestions"
                 className="flex-1 px-3 py-2 bg-ast-bg border border-ast-border rounded text-ast-text focus:outline-none focus:ring-2 focus:ring-ast-accent"
               />
+              <datalist id="theme-suggestions">
+                {availableThemes.map((theme) => (
+                  <option key={theme} value={theme} />
+                ))}
+              </datalist>
               <button
                 onClick={handleAddInterest}
                 className="px-4 py-2 bg-ast-accent text-ast-bg rounded font-medium hover:bg-ast-accent/90"
@@ -269,16 +292,19 @@ export default function ProfilePage() {
             <div className="space-y-2">
               {SEGMENTS.map((segment) => (
                 <label
-                  key={segment}
+                  key={segment.name}
                   className="flex items-center gap-3 p-2 hover:bg-ast-bg/50 rounded cursor-pointer"
                 >
                   <input
                     type="checkbox"
-                    checked={segments.includes(segment)}
-                    onChange={() => handleToggleSegment(segment)}
+                    checked={segments.includes(segment.name)}
+                    onChange={() => handleToggleSegment(segment.name)}
                     className="w-4 h-4 rounded border-ast-border text-ast-accent focus:ring-ast-accent"
                   />
-                  <span className="text-sm text-ast-text">{segment}</span>
+                  <div className="flex-1">
+                    <div className="text-sm text-ast-text">{segment.name}</div>
+                    <div className="text-xs text-ast-muted">{segment.description}</div>
+                  </div>
                 </label>
               ))}
             </div>


### PR DESCRIPTION
Closes #31, #32, #33

## Changes
- **Back button** (#31) — top of profile page, navigates to `/`
- **Segment explainers** (#33) — SEGMENTS now objects with `name` + `description`; descriptions render as `text-xs text-ast-muted` below each checkbox
- **Interests dropdown** (#32) — new `GET /api/tags/themes` endpoint queries `DISTINCT value FROM content_tags WHERE dimension = 'theme'`; profile input wired to `<datalist>` with suggestions; free-text fallback intact

`tsc --noEmit` passes clean.