### PR TITLE
feat: wire user prefs — seed interests filter + display name in header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -62,11 +62,23 @@ export function Header() {
   const router = useRouter();
   const supabase = createAuthBrowserClient();
   const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [displayName, setDisplayName] = useState<string | null>(null);
 
   useEffect(() => {
     const getUser = async () => {
       const { data: { session } } = await supabase.auth.getSession();
       setUserEmail(session?.user?.email || null);
+      
+      // Fetch display name from preferences
+      if (session?.user) {
+        try {
+          const res = await fetch('/api/user/preferences');
+          if (res.ok) {
+            const data = await res.json();
+            setDisplayName(data?.profile?.display_name || null);
+          }
+        } catch {}
+      }
     };
     getUser();
   }, [supabase]);
@@ -80,6 +92,16 @@ export function Header() {
   const getInitials = (email: string) => {
     const name = email.split("@")[0];
     return name.substring(0, 2).toUpperCase();
+  };
+
+  const getAvatarInitials = () => {
+    if (displayName) {
+      return displayName.substring(0, 2).toUpperCase();
+    }
+    if (userEmail) {
+      return getInitials(userEmail);
+    }
+    return "??";
   };
 
   return (
@@ -121,9 +143,9 @@ export function Header() {
             <Link
               href="/profile"
               className="w-7 h-7 rounded-full bg-ast-accent/20 border border-ast-accent/40 flex items-center justify-center text-ast-accent text-xs font-semibold hover:bg-ast-accent/30 transition-colors"
-              title="Profile"
+              title={displayName || userEmail || 'Profile'}
             >
-              {getInitials(userEmail)}
+              {getAvatarInitials()}
             </Link>
           )}
           <Link

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -267,6 +267,18 @@ export function LiveFeed({ initialItems, initialHasMore, sources }: LiveFeedProp
     setGlobalItems(items);
   }, [items]);
 
+  // Seed interests filter from user preferences on mount
+  useEffect(() => {
+    fetch('/api/user/preferences')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data?.preferences?.interests?.length) {
+          setFilters(prev => ({ ...prev, themes: data.preferences.interests }));
+        }
+      })
+      .catch(() => {}); // silent fail — unauthenticated users, network errors
+  }, []);
+
   const checkForNew = useCallback(async () => {
     try {
       // Use the newest known item's published_at as a "since" cursor.


### PR DESCRIPTION
Closes the gap between saved preferences and actual UI behavior.

## Changes
- **Interests → feed filter**: on LiveFeed mount, fetches `/api/user/preferences` and pre-seeds `filters.themes` with saved interests. Silent fail for unauthenticated users.
- **Display name in Header**: fetches display_name alongside session; avatar initials use display name if set, falls back to email. Tooltip shows full display name.

`tsc --noEmit` passes clean.