### PR TITLE
feat: admin pipeline dashboard tab

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -30,7 +30,7 @@ interface IngestionLogRow {
   duration_ms: number;
 }
 
-type Tab = "sources" | "health";
+type Tab = "sources" | "health" | "pipeline";
 type SortField = "name" | "type" | "articles" | "last_fetch" | "latest_article" | "status" | "errors";
 type SortDir = "asc" | "desc";
 
@@ -587,6 +587,342 @@ function FetchAllButton({ onDone }: { onDone: () => void }) {
   );
 }
 
+// ── Pipeline Dashboard ─────────────────────────────────────────────
+
+interface PipelineStats {
+  articles: { total: number; tagged: number; taggedPct: number };
+  tagsByDimension: { dimension: string; count: number }[];
+  signals: { 
+    total: number; 
+    byType: { signal_type: string; count: number }[]; 
+    lastCreatedAt: string | null 
+  };
+  importanceGate: { cleared: number; clearedNoSignal: number };
+  entityResolution: {
+    total: number;
+    resolved: number;
+    resolvedPct: number;
+    topUnresolved: { value: string; count: number }[];
+  };
+}
+
+interface HealthResponse {
+  status: string;
+  timestamp: string;
+  version: string;
+  uptime: number;
+}
+
+function PipelineDashboard() {
+  const [stats, setStats] = useState<PipelineStats | null>(null);
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [healthResponseTime, setHealthResponseTime] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const TEST_API_KEY = "ast_6c3732f0c3405ff36eeddcbc68af3f3e4593c9dd011f6419";
+  const BASE_URL = "https://terminal.always-scheming.com";
+
+  const fetchStats = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/pipeline");
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      setStats(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch stats");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const start = performance.now();
+      const res = await fetch("/api/v1/health");
+      const end = performance.now();
+      if (res.ok) {
+        const data = await res.json();
+        setHealth(data);
+        setHealthResponseTime(Math.round(end - start));
+      }
+    } catch (err) {
+      console.error("Health check failed:", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStats();
+    fetchHealth();
+  }, [fetchStats, fetchHealth]);
+
+  const copyToClipboard = (text: string, label: string) => {
+    navigator.clipboard.writeText(text);
+    setCopied(label);
+    setTimeout(() => setCopied(null), 2000);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-ast-muted text-sm">Loading pipeline stats...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-ast-surface border border-ast-border rounded-lg p-6 text-center">
+        <div className="text-ast-pink text-sm mb-2">Failed to load pipeline stats</div>
+        <div className="text-ast-muted text-xs mb-4">{error}</div>
+        <button
+          onClick={fetchStats}
+          className="px-4 py-2 rounded bg-ast-accent/10 border border-ast-accent/30 text-ast-accent text-xs hover:bg-ast-accent/20 transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!stats) return null;
+
+  return (
+    <div className="space-y-6">
+      {/* Header with refresh */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-ast-text">Pipeline Health</h2>
+        <button
+          onClick={() => { fetchStats(); fetchHealth(); }}
+          className="px-3 py-1.5 rounded bg-ast-accent/10 border border-ast-accent/30 text-ast-accent text-xs hover:bg-ast-accent/20 transition-colors"
+        >
+          ↻ Refresh
+        </button>
+      </div>
+
+      {/* Coverage Section */}
+      <div className="bg-ast-surface border border-ast-border rounded-lg p-4">
+        <h3 className="text-xs uppercase tracking-wider text-ast-muted font-semibold mb-3">
+          Coverage
+        </h3>
+        <div className="grid grid-cols-2 gap-3 mb-4">
+          <div>
+            <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1">
+              Total Articles
+            </div>
+            <div className="text-2xl font-bold text-ast-text">
+              {stats.articles.total}
+            </div>
+          </div>
+          <div>
+            <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1">
+              Tagged
+            </div>
+            <div className="text-2xl font-bold text-ast-accent">
+              {stats.articles.tagged}
+            </div>
+            <div className="text-[10px] text-ast-muted mt-0.5">
+              {stats.articles.taggedPct.toFixed(1)}% of total
+            </div>
+          </div>
+        </div>
+
+        {/* Dimension breakdown */}
+        {stats.tagsByDimension.length > 0 && (
+          <div className="border-t border-ast-border pt-3">
+            <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-2">
+              Tags by Dimension
+            </div>
+            <div className="space-y-1">
+              {stats.tagsByDimension.map((dim) => {
+                const pct = stats.articles.total > 0 
+                  ? ((dim.count / stats.articles.total) * 100).toFixed(1)
+                  : "0.0";
+                return (
+                  <div key={dim.dimension} className="flex items-center justify-between text-xs">
+                    <span className="text-ast-text capitalize">{dim.dimension}</span>
+                    <span className="text-ast-muted tabular-nums">
+                      {dim.count} <span className="text-ast-muted/60">({pct}%)</span>
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Signals Section */}
+      <div className="bg-ast-surface border border-ast-border rounded-lg p-4">
+        <h3 className="text-xs uppercase tracking-wider text-ast-muted font-semibold mb-3">
+          Signals
+        </h3>
+        <div className="grid grid-cols-3 gap-3 mb-4">
+          <div>
+            <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1">
+              Total Signals
+            </div>
+            <div className={`text-2xl font-bold ${stats.signals.total === 0 ? "text-ast-pink" : "text-ast-mint"}`}>
+              {stats.signals.total}
+            </div>
+          </div>
+          <div>
+            <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1">
+              Cleared Gate
+            </div>
+            <div className="text-2xl font-bold text-ast-text">
+              {stats.importanceGate.cleared}
+            </div>
+            <div className="text-[10px] text-ast-muted mt-0.5">
+              {stats.importanceGate.clearedNoSignal} no signal yet
+            </div>
+          </div>
+          <div>
+            <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1">
+              Last Signal
+            </div>
+            <div className={`text-sm font-semibold ${stats.signals.lastCreatedAt ? "text-ast-text" : "text-ast-pink"}`}>
+              {stats.signals.lastCreatedAt ? timeAgo(stats.signals.lastCreatedAt) : "Never"}
+            </div>
+          </div>
+        </div>
+
+        {/* Signals by type */}
+        {stats.signals.byType.length > 0 && (
+          <div className="border-t border-ast-border pt-3">
+            <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-2">
+              By Type
+            </div>
+            <div className="flex gap-2 flex-wrap">
+              {stats.signals.byType.map((st) => (
+                <span
+                  key={st.signal_type}
+                  className="px-2 py-1 rounded bg-ast-accent/10 border border-ast-accent/30 text-ast-accent text-xs"
+                >
+                  {st.signal_type}: {st.count}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Entity Resolution Section */}
+      <div className="bg-ast-surface border border-ast-border rounded-lg p-4">
+        <h3 className="text-xs uppercase tracking-wider text-ast-muted font-semibold mb-3">
+          Entity Resolution
+        </h3>
+        <div className="mb-4">
+          <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1">
+            Company Tags Resolved
+          </div>
+          <div className="text-2xl font-bold text-ast-text">
+            {stats.entityResolution.resolved} / {stats.entityResolution.total}
+          </div>
+          <div className="text-[10px] text-ast-muted mt-0.5">
+            {stats.entityResolution.resolvedPct.toFixed(1)}% coverage
+          </div>
+        </div>
+
+        {/* Top unresolved */}
+        {stats.entityResolution.topUnresolved.length > 0 && (
+          <div className="border-t border-ast-border pt-3">
+            <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-2">
+              Top Unresolved Tags
+            </div>
+            <div className="space-y-1">
+              {stats.entityResolution.topUnresolved.map((tag) => (
+                <div key={tag.value} className="flex items-center justify-between text-xs">
+                  <span className="text-ast-text">{tag.value}</span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-ast-muted tabular-nums">{tag.count}</span>
+                    <span className="text-[10px] text-ast-accent">add alias</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* API Readiness Section */}
+      <div className="bg-ast-surface border border-ast-border rounded-lg p-4">
+        <h3 className="text-xs uppercase tracking-wider text-ast-muted font-semibold mb-3">
+          API Readiness
+        </h3>
+        
+        {/* Health check */}
+        {health && (
+          <div className="mb-4 pb-3 border-b border-ast-border">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs text-ast-muted">Health Check</div>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-ast-text">
+                  {healthResponseTime !== null ? `${healthResponseTime}ms` : "—"}
+                </span>
+                <span className="text-xs text-ast-mint">v{health.version}</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Test API Key */}
+        <div className="mb-3">
+          <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1.5">
+            Test API Key
+          </div>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 px-2 py-1.5 bg-ast-bg border border-ast-border rounded text-xs font-mono text-ast-text truncate">
+              {TEST_API_KEY}
+            </code>
+            <button
+              onClick={() => copyToClipboard(TEST_API_KEY, "key")}
+              className="px-2 py-1.5 rounded bg-ast-accent/10 border border-ast-accent/30 text-ast-accent text-xs hover:bg-ast-accent/20 transition-colors"
+            >
+              {copied === "key" ? "✓" : "Copy"}
+            </button>
+          </div>
+        </div>
+
+        {/* Example curl commands */}
+        <div className="space-y-2">
+          <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1.5">
+            Example Requests
+          </div>
+          
+          {[
+            { label: "Items", cmd: `curl "${BASE_URL}/api/v1/items?limit=5" -H "Authorization: Bearer ${TEST_API_KEY}"` },
+            { label: "Signals", cmd: `curl "${BASE_URL}/api/v1/signals?limit=5" -H "Authorization: Bearer ${TEST_API_KEY}"` },
+            { label: "Entities", cmd: `curl "${BASE_URL}/api/v1/entities?alias=Roblox" -H "Authorization: Bearer ${TEST_API_KEY}"` },
+          ].map((item) => (
+            <div key={item.label} className="border border-ast-border rounded p-2">
+              <div className="flex items-center justify-between mb-1.5">
+                <span className="text-[10px] text-ast-accent uppercase tracking-wider font-semibold">
+                  {item.label}
+                </span>
+                <button
+                  onClick={() => copyToClipboard(item.cmd, item.label)}
+                  className="px-2 py-0.5 rounded bg-ast-accent/10 border border-ast-accent/30 text-ast-accent text-[10px] hover:bg-ast-accent/20 transition-colors"
+                >
+                  {copied === item.label ? "✓ Copied" : "Copy"}
+                </button>
+              </div>
+              <code className="block text-[10px] font-mono text-ast-muted break-all">
+                {item.cmd}
+              </code>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Main Admin Page ────────────────────────────────────────────────
 
 export default function AdminPage() {
@@ -728,6 +1064,16 @@ export default function AdminPage() {
           >
             Ingestion Health
           </button>
+          <button
+            onClick={() => setTab("pipeline")}
+            className={`px-4 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+              tab === "pipeline"
+                ? "border-ast-accent text-ast-accent"
+                : "border-transparent text-ast-muted hover:text-ast-text"
+            }`}
+          >
+            Pipeline
+          </button>
           <div className="ml-auto">
             <FetchAllButton onDone={() => { fetchSources(); fetchLogs(); }} />
           </div>
@@ -773,8 +1119,10 @@ export default function AdminPage() {
               </div>
             </div>
           </div>
-        ) : (
+        ) : tab === "health" ? (
           <HealthDashboard sources={sources} logs={logs} onRefresh={() => { fetchSources(); fetchLogs(); }} />
+        ) : (
+          <PipelineDashboard />
         )}
       </main>
     </div>

--- a/src/app/api/admin/pipeline/route.ts
+++ b/src/app/api/admin/pipeline/route.ts
@@ -1,0 +1,205 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { createAuthServerClient } from "@/lib/supabase-server";
+
+export const runtime = "nodejs";
+
+function getServiceRoleClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } }
+  );
+}
+
+export async function GET(req: NextRequest) {
+  // Auth check via session
+  const supabase = await createAuthServerClient();
+
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError || !session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Use service role client for queries
+  const serviceClient = getServiceRoleClient();
+
+  try {
+    // 1. Total articles
+    const { count: totalCount, error: totalError } = await serviceClient
+      .from("content")
+      .select("*", { count: "exact", head: true });
+
+    if (totalError) throw totalError;
+
+    // 2. Articles with any tags
+    const { count: taggedCount, error: taggedError } = await serviceClient
+      .from("content")
+      .select("*", { count: "exact", head: true })
+      .neq("tags", "{}")
+      .not("tags", "is", null);
+
+    if (taggedError) throw taggedError;
+
+    // 3. Tag counts by dimension - fetch all and group manually
+    const { data: allTags, error: tagsError } = await serviceClient
+      .from("content_tags")
+      .select("dimension");
+
+    if (tagsError) throw tagsError;
+
+    const dimensionCounts: Record<string, number> = {};
+    (allTags || []).forEach((row: { dimension: string }) => {
+      dimensionCounts[row.dimension] = (dimensionCounts[row.dimension] || 0) + 1;
+    });
+
+    const tagsByDimension = Object.entries(dimensionCounts)
+      .map(([dimension, count]) => ({ dimension, count }))
+      .sort((a, b) => b.count - a.count);
+
+    // 4. Signals total + by type
+    const { data: allSignals, error: signalsError } = await serviceClient
+      .from("signals")
+      .select("signal_type");
+
+    if (signalsError) throw signalsError;
+
+    const signalTypeCounts: Record<string, number> = {};
+    (allSignals || []).forEach((row: { signal_type: string }) => {
+      signalTypeCounts[row.signal_type] = (signalTypeCounts[row.signal_type] || 0) + 1;
+    });
+
+    const signalsByType = Object.entries(signalTypeCounts).map(
+      ([signal_type, count]) => ({ signal_type, count })
+    );
+
+    // Last signal created
+    const { data: lastSignalData, error: lastSignalError } =
+      await serviceClient
+        .from("signals")
+        .select("created_at")
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+    if (lastSignalError && lastSignalError.code !== "PGRST116")
+      throw lastSignalError;
+
+    // 5. Importance gate
+    const { count: clearedCount, error: clearedError } = await serviceClient
+      .from("content")
+      .select("*", { count: "exact", head: true })
+      .gte("importance_score", 0.4);
+
+    if (clearedError) throw clearedError;
+
+    // Articles cleared gate but no signal yet
+    const { data: clearedContentData, error: clearedContentError } =
+      await serviceClient
+        .from("content")
+        .select("id")
+        .gte("importance_score", 0.4);
+
+    if (clearedContentError) throw clearedContentError;
+
+    const clearedIds = (clearedContentData || []).map((row: { id: string }) => row.id);
+    let clearedNoSignal = 0;
+
+    if (clearedIds.length > 0) {
+      const { data: existingSignals, error: existingError } =
+        await serviceClient.from("signals").select("content_id");
+
+      if (existingError) throw existingError;
+
+      const signalContentIds = new Set(
+        (existingSignals || []).map((s: { content_id: string }) => s.content_id)
+      );
+      clearedNoSignal = clearedIds.filter((id: string) => !signalContentIds.has(id))
+        .length;
+    }
+
+    // 6. Entity resolution coverage
+    const { count: totalCompanyTags, error: totalCompanyError } =
+      await serviceClient
+        .from("content_tags")
+        .select("*", { count: "exact", head: true })
+        .eq("dimension", "company");
+
+    if (totalCompanyError) throw totalCompanyError;
+
+    const { count: resolvedCompanyTags, error: resolvedCompanyError } =
+      await serviceClient
+        .from("content_tags")
+        .select("*", { count: "exact", head: true })
+        .eq("dimension", "company")
+        .not("entity_id", "is", null);
+
+    if (resolvedCompanyError) throw resolvedCompanyError;
+
+    // 7. Top unresolved company tags
+    const { data: unresolvedTagsData, error: unresolvedError } =
+      await serviceClient
+        .from("content_tags")
+        .select("value")
+        .eq("dimension", "company")
+        .is("entity_id", null);
+
+    if (unresolvedError) throw unresolvedError;
+
+    const unresolvedCounts: Record<string, number> = {};
+    (unresolvedTagsData || []).forEach((row: { value: string }) => {
+      unresolvedCounts[row.value] = (unresolvedCounts[row.value] || 0) + 1;
+    });
+
+    const topUnresolved = Object.entries(unresolvedCounts)
+      .map(([value, count]) => ({ value, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    // Build response
+    const totalArticles = totalCount || 0;
+    const tagged = taggedCount || 0;
+    const taggedPct = totalArticles > 0 ? (tagged / totalArticles) * 100 : 0;
+
+    const totalSignals =
+      signalsByType.reduce((sum: number, s: { count: number }) => sum + s.count, 0) || 0;
+
+    const totalCompany = totalCompanyTags || 0;
+    const resolved = resolvedCompanyTags || 0;
+    const resolvedPct = totalCompany > 0 ? (resolved / totalCompany) * 100 : 0;
+
+    return NextResponse.json({
+      articles: {
+        total: totalArticles,
+        tagged,
+        taggedPct: Math.round(taggedPct * 10) / 10,
+      },
+      tagsByDimension,
+      signals: {
+        total: totalSignals,
+        byType: signalsByType,
+        lastCreatedAt: lastSignalData?.created_at || null,
+      },
+      importanceGate: {
+        cleared: clearedCount || 0,
+        clearedNoSignal,
+      },
+      entityResolution: {
+        total: totalCompany,
+        resolved,
+        resolvedPct: Math.round(resolvedPct * 10) / 10,
+        topUnresolved,
+      },
+    });
+  } catch (error) {
+    console.error("Pipeline stats error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch pipeline stats" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Adds a third 'Pipeline' tab to the admin page with full data quality visibility.

## New route: `/api/admin/pipeline`
Session-auth gated. Runs 7 queries against the service role client:
- Article count + tagged %
- Tag counts by dimension
- Signals total + by type + last created
- Importance gate: cleared count + cleared-with-no-signal
- Entity resolution: company tags resolved fraction + top 10 unresolved

## New tab: Pipeline
Four sections:
1. **Coverage** — total articles, tagged %, dimension breakdown table
2. **Signals** — total (pink if 0), by type, gate stats, last signal timestamp
3. **Entity Resolution** — resolved fraction/%, top unresolved company names
4. **API Readiness** — live `/api/v1/health` check with ms timing, test API key, 3 copy-to-clipboard curl commands

`tsc --noEmit` passes clean.