### PR TITLE
feat: admin role-gating — requireAdmin helper, trigger-ingest route, page guard, header link

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 
 interface SourceRow {
@@ -533,11 +534,8 @@ function FetchAllButton({ onDone }: { onDone: () => void }) {
     setFetching(true);
     setToast(null);
     try {
-      const res = await fetch("/api/ingest", {
+      const res = await fetch("/api/admin/trigger-ingest", {
         method: "POST",
-        headers: process.env.NEXT_PUBLIC_CRON_SECRET
-          ? { Authorization: `Bearer ${process.env.NEXT_PUBLIC_CRON_SECRET}` }
-          : {},
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Ingestion failed");
@@ -926,6 +924,7 @@ function PipelineDashboard() {
 // ── Main Admin Page ────────────────────────────────────────────────
 
 export default function AdminPage() {
+  const router = useRouter();
   const [sources, setSources] = useState<SourceRow[]>([]);
   const [logs, setLogs] = useState<IngestionLogRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -956,9 +955,25 @@ export default function AdminPage() {
   }, []);
 
   useEffect(() => {
+    // Check admin access
+    fetch("/api/user/preferences")
+      .then((r) => {
+        if (r.status === 401 || r.status === 403) {
+          router.push("/");
+          return;
+        }
+        return r.json();
+      })
+      .then((data) => {
+        if (data && data.profile?.role !== "admin") {
+          router.push("/");
+        }
+      })
+      .catch(() => {});
+
     fetchSources();
     fetchLogs();
-  }, [fetchSources, fetchLogs]);
+  }, [fetchSources, fetchLogs, router]);
 
   function handleSort(field: SortField) {
     if (field === sortField) {
@@ -1142,13 +1157,10 @@ function FetchButton({ sourceId, onDone }: { sourceId: string; onDone: () => voi
     setFetching(true);
     setResult(null);
     try {
-      const res = await fetch("/api/ingest/source", {
+      const res = await fetch("/api/admin/trigger-ingest-source", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...(process.env.NEXT_PUBLIC_CRON_SECRET
-            ? { Authorization: `Bearer ${process.env.NEXT_PUBLIC_CRON_SECRET}` }
-            : {}),
         },
         body: JSON.stringify({ source_id: sourceId }),
       });

--- a/src/app/api/admin/trigger-ingest-source/route.ts
+++ b/src/app/api/admin/trigger-ingest-source/route.ts
@@ -1,0 +1,29 @@
+import { requireAdmin } from '@/lib/admin-auth';
+import { NextResponse } from 'next/server';
+import { ingestOne } from '@/lib/ingest';
+
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  const auth = await requireAdmin();
+  if (auth instanceof NextResponse) return auth;
+
+  const body = await req.json();
+  const { source_id } = body;
+
+  if (!source_id) {
+    return NextResponse.json({ error: 'source_id is required' }, { status: 400 });
+  }
+
+  try {
+    const result = await ingestOne(source_id);
+
+    return NextResponse.json({
+      ok: result.errors.length === 0,
+      result,
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/trigger-ingest/route.ts
+++ b/src/app/api/admin/trigger-ingest/route.ts
@@ -1,0 +1,24 @@
+import { requireAdmin } from '@/lib/admin-auth';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  const auth = await requireAdmin();
+  if (auth instanceof NextResponse) return auth;
+
+  // Forward to /api/ingest with the server-side secret
+  const cronSecret = process.env.CRON_SECRET;
+  const ingestUrl = new URL('/api/ingest', process.env.NEXT_PUBLIC_SITE_URL || 'https://terminal.always-scheming.com').toString();
+
+  const res = await fetch(ingestUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(cronSecret ? { Authorization: `Bearer ${cronSecret}` } : {}),
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -63,19 +63,20 @@ export function Header() {
   const supabase = createAuthBrowserClient();
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [displayName, setDisplayName] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     const getUser = async () => {
       const { data: { session } } = await supabase.auth.getSession();
       setUserEmail(session?.user?.email || null);
-      
-      // Fetch display name from preferences
-      if (session?.user) {
+
+      if (session) {
         try {
-          const res = await fetch('/api/user/preferences');
-          if (res.ok) {
-            const data = await res.json();
-            setDisplayName(data?.profile?.display_name || null);
+          const prefsRes = await fetch('/api/user/preferences');
+          if (prefsRes.ok) {
+            const data = await prefsRes.json();
+            setIsAdmin(data.profile?.role === 'admin');
+            setDisplayName(data.profile?.display_name || null);
           }
         } catch {}
       }
@@ -89,9 +90,8 @@ export function Header() {
     router.refresh();
   };
 
-  const getInitials = (email: string) => {
-    const name = email.split("@")[0];
-    return name.substring(0, 2).toUpperCase();
+  const getInitials = (text: string) => {
+    return text.substring(0, 2).toUpperCase();
   };
 
   const getAvatarInitials = () => {
@@ -148,12 +148,14 @@ export function Header() {
               {getAvatarInitials()}
             </Link>
           )}
-          <Link
-            href="/admin"
-            className="hidden sm:inline text-ast-muted hover:text-ast-accent text-xs transition-colors"
-          >
-            ⚙ Admin
-          </Link>
+          {isAdmin && (
+            <Link
+              href="/admin"
+              className="hidden sm:inline text-ast-muted hover:text-ast-accent text-xs transition-colors"
+            >
+              ⚙ Admin
+            </Link>
+          )}
           <button
             onClick={handleSignOut}
             className="text-ast-muted hover:text-red-400 text-xs transition-colors"

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,31 @@
+import { createAuthServerClient } from '@/lib/supabase-server';
+import { NextResponse } from 'next/server';
+
+export async function requireAdmin(): Promise<{ userId: string } | NextResponse> {
+  const supabase = await createAuthServerClient();
+  const { data: { session }, error } = await supabase.auth.getSession();
+  
+  if (error || !session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Check role in profiles table using service role client to bypass RLS
+  const { createClient } = await import('@supabase/supabase-js');
+  const serviceClient = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } }
+  );
+
+  const { data: profile } = await serviceClient
+    .from('profiles')
+    .select('role')
+    .eq('id', session.user.id)
+    .single();
+
+  if (profile?.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  return { userId: session.user.id };
+}


### PR DESCRIPTION
Closes the admin security gap. heavymateria@gmail.com is the only admin (set via SQL on profiles.role).

## Changes
- **`src/lib/admin-auth.ts`** — `requireAdmin()` helper: checks session + queries `profiles.role` via service client, returns 401/403 NextResponse if not admin
- **`/api/admin/trigger-ingest`** — admin-only POST that forwards to `/api/ingest` with `CRON_SECRET` server-side. Fixes broken Fetch All button.
- **`/api/admin/trigger-ingest-source`** — same pattern for per-source fetch
- **`/api/admin/pipeline`** — updated to use `requireAdmin()` instead of session-only check
- **Admin page** — redirects to `/` on 401/403; Fetch All + per-source buttons now call the new admin routes
- **Header** — Admin link hidden for non-admin users; avatar uses display_name if set

`tsc --noEmit` passes clean.