### PR TITLE
feat: admin extract-signals endpoint + Run Extraction button

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -611,6 +611,46 @@ interface HealthResponse {
   uptime: number;
 }
 
+function ExtractSignalsButton({ onDone }: { onDone: () => void }) {
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  async function handleExtract() {
+    setRunning(true);
+    setResult(null);
+    try {
+      const res = await fetch("/api/admin/extract-signals", { method: "POST" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed");
+      const s = data.summary;
+      setResult({ ok: true, msg: `${s.extracted} extracted · ${s.alreadySignaled} already done · ${s.totalSignalsInDb} total` });
+      onDone();
+    } catch (err: unknown) {
+      setResult({ ok: false, msg: err instanceof Error ? err.message : "Failed" });
+    } finally {
+      setRunning(false);
+      setTimeout(() => setResult(null), 8000);
+    }
+  }
+
+  return (
+    <div className="mt-2">
+      <button
+        onClick={handleExtract}
+        disabled={running}
+        className="px-2 py-1 text-[10px] rounded border border-ast-accent/30 text-ast-accent hover:bg-ast-accent/10 disabled:opacity-50 transition-colors"
+      >
+        {running ? "Extracting..." : "Run Extraction"}
+      </button>
+      {result && (
+        <div className={`text-[10px] mt-1 ${result.ok ? "text-ast-mint" : "text-ast-pink"}`}>
+          {result.msg}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function PipelineDashboard() {
   const [stats, setStats] = useState<PipelineStats | null>(null);
   const [health, setHealth] = useState<HealthResponse | null>(null);
@@ -768,6 +808,7 @@ function PipelineDashboard() {
             <div className={`text-2xl font-bold ${stats.signals.total === 0 ? "text-ast-pink" : "text-ast-mint"}`}>
               {stats.signals.total}
             </div>
+            <ExtractSignalsButton onDone={fetchStats} />
           </div>
           <div>
             <div className="text-[10px] text-ast-muted uppercase tracking-wider mb-1">

--- a/src/app/api/admin/extract-signals/route.ts
+++ b/src/app/api/admin/extract-signals/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { requireAdmin } from "@/lib/admin-auth";
+import { extractSignal } from "@/lib/signal-extractor";
+
+export const runtime = "nodejs";
+// Allow up to 5 minutes — this is a backfill that may process many articles
+export const maxDuration = 300;
+
+function getServiceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } }
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin();
+  if (auth instanceof NextResponse) return auth;
+
+  const supabase = getServiceClient();
+
+  // Get articles with company + category tags that don't have signals yet
+  const { data: items, error: fetchError } = await supabase
+    .from("content")
+    .select("id, title, body, tags, sources!inner(source_type)")
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .limit(200); // process in batches of 200
+
+  if (fetchError) {
+    return NextResponse.json({ error: fetchError.message }, { status: 500 });
+  }
+
+  // Filter: must have company + category tags
+  const eligible = (items || []).filter((item) => {
+    const tags = (item.tags as Record<string, string[]>) || {};
+    return tags.company?.length > 0 && tags.category?.length > 0;
+  });
+
+  // Filter out already-signaled articles
+  const eligibleIds = eligible.map((i) => i.id);
+  const { data: existingSignals } = await supabase
+    .from("signals")
+    .select("item_id")
+    .in("item_id", eligibleIds);
+
+  const signaled = new Set((existingSignals || []).map((s: any) => s.item_id));
+  const todo = eligible.filter((i) => !signaled.has(i.id));
+
+  let extracted = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const item of todo) {
+    const tags = (item.tags as Record<string, string[]>) || {};
+    const hasResolvedEntity = (tags.company || []).length > 0;
+
+    await extractSignal({
+      supabase,
+      item: {
+        id: item.id,
+        title: item.title,
+        body: item.body,
+        tags: item.tags as Record<string, string[]>,
+        sources: { source_type: (item.sources as any).source_type },
+      },
+      hasResolvedEntity,
+    });
+
+    extracted++;
+  }
+
+  skipped = eligible.length - todo.length;
+
+  const { count: totalSignals } = await supabase
+    .from("signals")
+    .select("*", { count: "exact", head: true });
+
+  return NextResponse.json({
+    ok: true,
+    summary: {
+      eligible: eligible.length,
+      alreadySignaled: skipped,
+      processed: todo.length,
+      extracted,
+      failed,
+      totalSignalsInDb: totalSignals,
+    },
+  });
+}


### PR DESCRIPTION
Enables signal backfill from the admin Pipeline tab.

## Why
Signal extraction requires `GOOGLE_AI_API_KEY` which only exists in Vercel production. Can't run the backfill script locally. Need an admin-triggered endpoint.

## New route: POST /api/admin/extract-signals
- Admin-gated (`requireAdmin()`)
- Fetches up to 200 articles with company + category tags, no existing signal
- Calls `extractSignal()` for each — same logic as ingest, runs in production with the real key
- Returns summary: eligible / already signaled / extracted / total in DB

## Admin UI
'Run Extraction' button under the Signals count on the Pipeline tab. Shows result inline, refreshes stats on completion.

`tsc --noEmit` passes clean.