### PR TITLE
fix: login screen design polish

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { createAuthBrowserClient } from "@/lib/supabase";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -10,6 +11,7 @@ export default function LoginPage() {
   const [inviteCode, setInviteCode] = useState("");
   const [isSignUp, setIsSignUp] = useState(false);
   const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
   const supabase = createAuthBrowserClient();
@@ -17,42 +19,28 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setSuccess("");
     setLoading(true);
 
     try {
       if (isSignUp) {
-        // Validate invite code on signup
         const requiredCode = process.env.NEXT_PUBLIC_BETA_INVITE_CODE;
         if (!requiredCode) {
           setError("Beta invites are not configured");
           setLoading(false);
           return;
         }
-
         if (inviteCode !== requiredCode) {
           setError("Invalid invite code");
           setLoading(false);
           return;
         }
-
-        const { error: signUpError } = await supabase.auth.signUp({
-          email,
-          password,
-        });
-
+        const { error: signUpError } = await supabase.auth.signUp({ email, password });
         if (signUpError) throw signUpError;
-
-        // Show success message
-        setError("Check your email to confirm your account!");
+        setSuccess("Check your email to confirm your account.");
       } else {
-        const { error: signInError } = await supabase.auth.signInWithPassword({
-          email,
-          password,
-        });
-
+        const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
         if (signInError) throw signInError;
-
-        // Redirect to home
         router.push("/");
         router.refresh();
       }
@@ -64,105 +52,148 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0e27] flex items-center justify-center p-4">
-      <div className="w-full max-w-md">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">
-            Always Scheming Terminal
-          </h1>
-          <p className="text-gray-400">
-            {isSignUp ? "Create your account" : "Sign in to continue"}
+    <div className="min-h-screen bg-ast-bg flex items-center justify-center p-4">
+      {/* Subtle grid background */}
+      <div
+        className="fixed inset-0 pointer-events-none"
+        style={{
+          backgroundImage: `linear-gradient(rgba(119,196,217,0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(119,196,217,0.03) 1px, transparent 1px)`,
+          backgroundSize: "48px 48px",
+        }}
+      />
+
+      <div className="relative w-full max-w-sm">
+        {/* Logo + wordmark */}
+        <div className="flex flex-col items-center mb-10">
+          <div className="flex items-center gap-3 mb-3">
+            <Image src="/logo.png" alt="Always Scheming" width={32} height={32} className="w-7 h-7" />
+            <span className="font-mono font-semibold text-base tracking-tight">
+              <span className="text-ast-accent">Always</span>
+              <span className="text-ast-pink"> Scheming</span>
+              <span className="text-ast-text"> Terminal</span>
+            </span>
+          </div>
+          <p className="text-xs text-ast-muted font-mono tracking-wider uppercase">
+            Gaming industry intelligence
           </p>
         </div>
 
-        <form
-          onSubmit={handleSubmit}
-          className="bg-[#1a1f3a] rounded-lg p-8 space-y-6"
-        >
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-gray-300 mb-2"
-            >
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="w-full px-4 py-2 bg-[#0a0e27] border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor="password"
-              className="block text-sm font-medium text-gray-300 mb-2"
-            >
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              minLength={6}
-              className="w-full px-4 py-2 bg-[#0a0e27] border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
-
-          {isSignUp && (
-            <div>
-              <label
-                htmlFor="inviteCode"
-                className="block text-sm font-medium text-gray-300 mb-2"
-              >
-                Invite Code
-              </label>
-              <input
-                id="inviteCode"
-                type="text"
-                value={inviteCode}
-                onChange={(e) => setInviteCode(e.target.value)}
-                required
-                className="w-full px-4 py-2 bg-[#0a0e27] border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-          )}
-
-          {error && (
-            <div className="text-red-400 text-sm bg-red-900/20 border border-red-800 rounded-md p-3">
-              {error}
-            </div>
-          )}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium py-2 px-4 rounded-md transition-colors"
-          >
-            {loading ? "Loading..." : isSignUp ? "Sign Up" : "Sign In"}
-          </button>
-
-          <div className="text-center">
+        {/* Card */}
+        <div className="bg-ast-surface border border-ast-border rounded-lg overflow-hidden">
+          {/* Tab strip */}
+          <div className="flex border-b border-ast-border">
             <button
               type="button"
-              onClick={() => {
-                setIsSignUp(!isSignUp);
-                setError("");
-                setInviteCode("");
-              }}
-              className="text-sm text-gray-400 hover:text-white transition-colors"
+              onClick={() => { setIsSignUp(false); setError(""); setSuccess(""); }}
+              className={`flex-1 py-3 text-xs font-mono font-medium tracking-wider uppercase transition-colors ${
+                !isSignUp
+                  ? "text-ast-accent border-b-2 border-ast-accent bg-ast-accent/5"
+                  : "text-ast-muted hover:text-ast-text"
+              }`}
             >
-              {isSignUp
-                ? "Already have an account? Sign in"
-                : "Need an account? Sign up"}
+              Sign In
+            </button>
+            <button
+              type="button"
+              onClick={() => { setIsSignUp(true); setError(""); setSuccess(""); }}
+              className={`flex-1 py-3 text-xs font-mono font-medium tracking-wider uppercase transition-colors ${
+                isSignUp
+                  ? "text-ast-accent border-b-2 border-ast-accent bg-ast-accent/5"
+                  : "text-ast-muted hover:text-ast-text"
+              }`}
+            >
+              Sign Up
             </button>
           </div>
-        </form>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="p-6 space-y-4">
+            <div>
+              <label className="block text-[10px] font-mono text-ast-muted uppercase tracking-wider mb-1.5">
+                Email
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                placeholder="you@example.com"
+                className="w-full px-3 py-2 bg-ast-bg border border-ast-border rounded text-sm text-ast-text font-mono placeholder:text-ast-muted/40 focus:outline-none focus:border-ast-accent focus:ring-1 focus:ring-ast-accent/30 transition-colors"
+              />
+            </div>
+
+            <div>
+              <label className="block text-[10px] font-mono text-ast-muted uppercase tracking-wider mb-1.5">
+                Password
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={6}
+                autoComplete={isSignUp ? "new-password" : "current-password"}
+                placeholder="••••••••"
+                className="w-full px-3 py-2 bg-ast-bg border border-ast-border rounded text-sm text-ast-text font-mono placeholder:text-ast-muted/40 focus:outline-none focus:border-ast-accent focus:ring-1 focus:ring-ast-accent/30 transition-colors"
+              />
+            </div>
+
+            {isSignUp && (
+              <div>
+                <label className="block text-[10px] font-mono text-ast-muted uppercase tracking-wider mb-1.5">
+                  Invite Code
+                </label>
+                <input
+                  type="text"
+                  value={inviteCode}
+                  onChange={(e) => setInviteCode(e.target.value)}
+                  required
+                  autoComplete="off"
+                  placeholder="XXXXXXXX"
+                  className="w-full px-3 py-2 bg-ast-bg border border-ast-border rounded text-sm text-ast-text font-mono placeholder:text-ast-muted/40 focus:outline-none focus:border-ast-accent focus:ring-1 focus:ring-ast-accent/30 transition-colors tracking-widest"
+                />
+                <p className="text-[10px] text-ast-muted font-mono mt-1.5">
+                  Private beta — invite required
+                </p>
+              </div>
+            )}
+
+            {error && (
+              <div className="flex items-start gap-2 px-3 py-2 bg-ast-pink/10 border border-ast-pink/30 rounded text-xs text-ast-pink font-mono">
+                <span className="mt-0.5 flex-shrink-0">✕</span>
+                <span>{error}</span>
+              </div>
+            )}
+
+            {success && (
+              <div className="flex items-start gap-2 px-3 py-2 bg-ast-mint/10 border border-ast-mint/30 rounded text-xs text-ast-mint font-mono">
+                <span className="mt-0.5 flex-shrink-0">✓</span>
+                <span>{success}</span>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full mt-2 py-2.5 bg-ast-accent text-ast-bg text-sm font-mono font-semibold rounded hover:bg-ast-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors tracking-wide"
+            >
+              {loading ? (
+                <span className="inline-flex items-center gap-2">
+                  <span className="w-3 h-3 border border-ast-bg/40 border-t-ast-bg rounded-full animate-spin" />
+                  {isSignUp ? "Creating account..." : "Signing in..."}
+                </span>
+              ) : (
+                isSignUp ? "Create Account →" : "Sign In →"
+              )}
+            </button>
+          </form>
+        </div>
+
+        {/* Footer */}
+        <p className="text-center text-[10px] text-ast-muted/50 font-mono mt-6 tracking-wide">
+          Private beta · Invite only
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #45. Replaces hardcoded hex/blue colors with AST design system throughout.

## Changes
- Full AST token usage: `ast-bg`, `ast-surface`, `ast-border`, `ast-accent`, `ast-pink`, `ast-mint`, `ast-muted`
- JetBrains Mono font (matches terminal aesthetic)
- Tab strip for Sign In / Sign Up (cleaner than toggle link)
- Subtle dot-grid background texture
- Logo + wordmark lockup at top
- Colored error/success states (pink/mint with icon)
- Spinner on loading state
- Invite code field with tracking-widest for code feel
- Private beta footer note
- Splits error message state from success state properly

`tsc --noEmit` passes clean.