### PR TITLE
fix: update Gemini model slug to gemini-2.5-flash-lite

### DIFF
--- a/src/app/api/admin/extract-signals/route.ts
+++ b/src/app/api/admin/extract-signals/route.ts
@@ -41,7 +41,7 @@ Return ONLY valid JSON, no markdown:
 
   try {
     const res = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -134,7 +134,7 @@ export async function POST(req: NextRequest) {
       summary: signal.summary,
       investment_relevance_score: signal.investment_relevance_score,
       raw_llm_output: signal as any,
-      model_used: "gemini-2.0-flash",
+      model_used: "gemini-2.5-flash-lite",
     });
 
     if (insertError) {

--- a/src/lib/signal-extractor.ts
+++ b/src/lib/signal-extractor.ts
@@ -108,7 +108,7 @@ async function extractSignalWithLLM(
     const timeoutId = setTimeout(() => controller.abort(), 6000);
 
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -200,7 +200,7 @@ export async function extractSignal(options: ExtractSignalOptions): Promise<void
       summary: signal.summary,
       investment_relevance_score: signal.investment_relevance_score,
       raw_llm_output: signal as unknown as SignalInsert["raw_llm_output"],
-      model_used: "gemini-2.0-flash",
+      model_used: "gemini-2.5-flash-lite",
     };
 
     const { error } = await supabase.from("signals").insert(payload);

--- a/src/lib/tagger.ts
+++ b/src/lib/tagger.ts
@@ -303,7 +303,7 @@ Content: ${excerpt}`;
 
   const call = async (): Promise<{ company: string[]; theme: string[] }> => {
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
gemini-2.0-flash is deprecated and returning 404s. Updated all 5 occurrences across signal-extractor.ts, tagger.ts, and the admin extract-signals route.