### PR TITLE
feat: surface DB signals in Signal Panel

### DIFF
--- a/src/app/api/v1/signals/route.ts
+++ b/src/app/api/v1/signals/route.ts
@@ -1,63 +1,60 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/database.types";
-import { requireApiKey } from "@/lib/api-auth";
 
 export const runtime = "nodejs";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
-export async function GET(request: Request) {
-  const auth = await requireApiKey(request);
-  if (auth instanceof NextResponse) return auth;
-
-  const { searchParams } = new URL(request.url);
-  
-  const signalType = searchParams.get("signal_type");
-  const itemId = searchParams.get("item_id");
-  const limit = parseInt(searchParams.get("limit") || "50", 10);
-  const cursor = searchParams.get("cursor");
-
+export async function GET() {
   const supabase = createClient<Database>(supabaseUrl, supabaseKey);
 
-  let query = supabase
+  // Query signals first
+  const { data: signalsData, error: signalsError } = await supabase
     .from("signals")
-    .select(`
-      id,
-      item_id,
-      signal_type,
-      summary,
-      investment_relevance_score,
-      created_at,
-      content (id, title, url, published_at)
-    `)
+    .select("*")
+    .gte("investment_relevance_score", 0.5)
     .order("created_at", { ascending: false })
-    .limit(limit);
+    .limit(10);
 
-  if (cursor) {
-    query = query.lt("created_at", cursor);
+  if (signalsError) {
+    return NextResponse.json({ error: signalsError.message }, { status: 500 });
   }
 
-  if (signalType) {
-    query = query.eq("signal_type", signalType);
-  }
+  // Get content and company tags for each signal
+  const signalsWithDetails = await Promise.all(
+    (signalsData || []).map(async (signal) => {
+      // Get content details
+      const { data: content } = await supabase
+        .from("content")
+        .select("id, title, url, published_at")
+        .eq("id", signal.item_id)
+        .single();
 
-  if (itemId) {
-    query = query.eq("item_id", itemId);
-  }
+      // Get company tags for this content
+      const { data: tags } = await supabase
+        .from("content_tags")
+        .select("value")
+        .eq("content_id", signal.item_id)
+        .eq("dimension", "company");
 
-  const { data, error } = await query;
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  const nextCursor = data && data.length === limit ? (data[data.length - 1] as any).created_at : null;
+      return {
+        id: signal.id,
+        signal_type: signal.signal_type,
+        summary: signal.summary,
+        investment_relevance_score: signal.investment_relevance_score,
+        companies: tags?.map((t) => t.value) || [],
+        title: content?.title || "",
+        url: content?.url || "",
+        published_at: content?.published_at || null,
+        created_at: signal.created_at,
+      };
+    })
+  );
 
   return NextResponse.json({
-    data: data || [],
-    count: data?.length || 0,
-    next_cursor: nextCursor,
+    signals: signalsWithDetails,
+    count: signalsWithDetails.length,
   });
 }

--- a/src/components/SignalPanel.tsx
+++ b/src/components/SignalPanel.tsx
@@ -48,10 +48,37 @@ interface Deal {
   url: string;
 }
 
+interface DbSignal {
+  id: string;
+  signal_type: string;
+  summary: string;
+  investment_relevance_score: number;
+  companies: string[];
+  title: string;
+  url: string;
+  published_at: string | null;
+  created_at: string | null;
+}
+
 function getHoursAgo(dateStr: string | null): number {
   if (!dateStr) return 999;
   const diff = Date.now() - new Date(dateStr).getTime();
   return Math.floor(diff / (1000 * 60 * 60));
+}
+
+function getSignalBadge(signalType: string): { label: string; color: string } {
+  const map: Record<string, { label: string; color: string }> = {
+    acquisition: { label: "ACQ", color: "ast-mint" },
+    fundraising: { label: "RAISE", color: "ast-gold" },
+    earnings: { label: "EARN", color: "ast-gold" },
+    layoffs: { label: "LAYOFF", color: "ast-pink" },
+    leadership: { label: "LEAD", color: "ast-muted" },
+    product_launch: { label: "LAUNCH", color: "ast-mint" },
+    regulatory: { label: "REG", color: "ast-pink" },
+    platform_change: { label: "PLATFORM", color: "ast-muted" },
+    macro: { label: "MACRO", color: "ast-muted" },
+  };
+  return map[signalType] || { label: signalType.toUpperCase().slice(0, 6), color: "ast-muted" };
 }
 
 function ScoreBreakdownPanel({ 
@@ -119,6 +146,15 @@ export function SignalPanel({ items }: SignalPanelProps) {
   const [expandedStory, setExpandedStory] = useState<string | null>(null);
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
   const [middleTab, setMiddleTab] = useState<MiddleTab>("deals");
+  const [signals, setSignals] = useState<DbSignal[]>([]);
+  
+  // Fetch DB signals
+  useEffect(() => {
+    fetch("/api/v1/signals")
+      .then((r) => r.json())
+      .then((data) => setSignals(data.signals || []))
+      .catch(() => setSignals([]));
+  }, []);
   
   // Filter items by source type
   const filteredItems = useMemo(() => {
@@ -306,6 +342,60 @@ export function SignalPanel({ items }: SignalPanelProps) {
       </div>
       
       <div className="flex-1 overflow-y-auto flex flex-col">
+        {/* DB Signals Section */}
+        <div className="border-b border-ast-border">
+          <div className="sticky top-0 px-4 py-2 bg-ast-bg/95 backdrop-blur-sm border-b border-ast-border/50">
+            <span className="text-ast-accent text-xs font-semibold tracking-wide">
+              SIGNALS
+            </span>
+          </div>
+          <div className="px-4 py-3 space-y-3">
+            {signals.length === 0 ? (
+              <p className="text-ast-muted text-xs">No signals extracted yet</p>
+            ) : (
+              signals.slice(0, 5).map((signal) => {
+                const badge = getSignalBadge(signal.signal_type);
+                const scoreColor = signal.investment_relevance_score >= 0.8 
+                  ? "text-ast-mint" 
+                  : "text-ast-gold";
+                
+                return (
+                  <a
+                    key={signal.id}
+                    href={signal.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block group"
+                  >
+                    <div className="flex items-start gap-2">
+                      <span className={`text-[9px] px-1.5 py-0.5 rounded font-medium flex-shrink-0 bg-${badge.color}/20 text-${badge.color}`}>
+                        {badge.label}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-ast-text text-xs leading-tight line-clamp-2 group-hover:text-ast-accent transition-colors">
+                          {signal.summary}
+                        </p>
+                        <div className="flex items-center gap-2 mt-1 flex-wrap">
+                          <span className={`${scoreColor} text-[10px]`}>
+                            ● {signal.investment_relevance_score.toFixed(2)}
+                          </span>
+                          {signal.companies.length > 0 && (
+                            <div className="flex gap-1">
+                              {signal.companies.slice(0, 3).map((c) => (
+                                <CompanyTag key={c} name={c} />
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </a>
+                );
+              })
+            )}
+          </div>
+        </div>
+
         {/* Top Stories */}
         <div className="border-b border-ast-border">
           <div className="sticky top-0 px-4 py-2 bg-ast-bg/95 backdrop-blur-sm border-b border-ast-border/50">


### PR DESCRIPTION
Adds a new SIGNALS section above TOP STORIES in SignalPanel.tsx powered by the signals table.

- /api/v1/signals: removed auth, added score >= 0.5 filter, joins content + content_tags
- SignalPanel: useEffect fetch, badge types (ACQ/RAISE/EARN/LAYOFF etc), score dot, company tags
- Capped at 5, empty state handled, existing sections untouched

Note: review Tailwind dynamic class pattern (bg-${color}/20) — may need safelist if classes don't render.