### PR TITLE
feat: auto-trigger signal extraction after ingest cron

### DIFF
--- a/src/app/api/admin/extract-signals/route.ts
+++ b/src/app/api/admin/extract-signals/route.ts
@@ -85,8 +85,13 @@ Return ONLY valid JSON, no markdown:
 }
 
 export async function POST(req: NextRequest) {
-  const auth = await requireAdmin();
-  if (auth instanceof NextResponse) return auth;
+  // Allow Vercel cron to bypass admin auth
+  const isCron = req.headers.get("x-vercel-cron") === "1";
+  
+  if (!isCron) {
+    const auth = await requireAdmin();
+    if (auth instanceof NextResponse) return auth;
+  }
 
   const supabase = getServiceClient();
 

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/ingest",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/admin/extract-signals",
+      "schedule": "15 8 * * *"
     }
   ]
 }


### PR DESCRIPTION
Closes kanban t_c891e9ce.

## What's in this PR
- `vercel.json` — second cron entry: `/api/admin/extract-signals` at 8:15am UTC daily (15 min after ingest)
- `src/app/api/admin/extract-signals/route.ts` — cron bypass: `x-vercel-cron: 1` header skips `requireAdmin()` auth check

Manual triggers from the admin dashboard continue to work normally.