### PR TITLE
fix: subtle mint hover highlight on feed + signal rows

### DIFF
--- a/src/components/FeedRow.tsx
+++ b/src/components/FeedRow.tsx
@@ -125,7 +125,7 @@ export function FeedRow({ item }: FeedRowProps) {
         target="_blank"
         rel="noopener noreferrer"
         data-feed-item
-        className="block py-3 px-3 hover:bg-ast-surface/50 transition-colors group"
+        className="block py-3 px-3 hover:bg-ast-mint/5 transition-colors group"
       >
         <div className="flex items-start gap-2 sm:gap-3">
           {/* Timestamp — desktop only (separate column) */}

--- a/src/components/SignalPanel.tsx
+++ b/src/components/SignalPanel.tsx
@@ -365,7 +365,7 @@ export function SignalPanel({ items }: SignalPanelProps) {
                     href={signal.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block group"
+                    className="block group rounded hover:bg-ast-mint/5 transition-colors -mx-2 px-2"
                   >
                     <div className="flex items-start gap-2">
                       <span className={`text-[9px] px-1.5 py-0.5 rounded font-medium flex-shrink-0 bg-${badge.color}/20 text-${badge.color}`}>


### PR DESCRIPTION
- FeedRow: hover:bg-ast-surface/50 → hover:bg-ast-mint/5
- SignalPanel signals section: block group → block group + hover:bg-ast-mint/5 (signals rows only, deals/reading untouched)