### PR TITLE
Unify company detail view: CompanyTray modal → CompanyDrawer

### DIFF
--- a/src/components/CompanyTray.tsx
+++ b/src/components/CompanyTray.tsx
@@ -5,11 +5,10 @@ import { createPortal } from "react-dom";
 import { fetchEntityByAlias, type EntityData } from "@/lib/entity-client";
 import type { FeedItem } from "@/lib/database.types";
 import { TimeAgo } from "./TimeAgo";
+import { openCompanyDrawer } from "./CompanyDrawer";
 
 interface CompanyTrayProps {
   items: FeedItem[];
-  selectedCompany: string | null;
-  onSelectCompany: (name: string | null) => void;
 }
 
 type ChartRange = "1d" | "1w" | "1mo" | "3mo" | "6mo" | "1y";
@@ -129,27 +128,19 @@ function CompanyCard({
   companyData,
   stockData,
   mentionCount,
-  isExpanded,
-  onClick,
 }: { 
   name: string;
   companyData: EntityData | null;
   stockData: StockData;
   mentionCount: number;
-  isExpanded: boolean;
-  onClick: () => void;
 }) {
   const { quote, history, loading } = stockData;
   const isPositive = (quote?.change ?? 0) >= 0;
   
   return (
     <button
-      onClick={onClick}
-      className={`w-full p-3 rounded-lg border text-left transition-all ${
-        isExpanded 
-          ? "border-ast-accent bg-ast-accent/5 shadow-md" 
-          : "border-ast-border hover:border-ast-muted bg-ast-surface/50 hover:bg-ast-surface"
-      }`}
+      onClick={() => openCompanyDrawer(companyData?.canonical_name || name)}
+      className="w-full p-3 rounded-lg border text-left transition-all border-ast-border hover:border-ast-muted bg-ast-surface/50 hover:bg-ast-surface"
     >
       {/* Header row */}
       <div className="flex items-center justify-between gap-2 mb-1.5">
@@ -372,177 +363,6 @@ function InteractiveChart({
           <div className="text-ast-muted text-[10px]">{formatDate(hoverPoint.date)}</div>
         </div>
       )}
-    </div>
-  );
-}
-
-// Company Modal - centered modal matching IndexModal style
-function CompanyModal({ 
-  companyData,
-  stockData,
-  items,
-  chartRange,
-  onRangeChange,
-  onClose,
-}: { 
-  companyData: EntityData;
-  stockData: StockData;
-  items: FeedItem[];
-  chartRange: ChartRange;
-  onRangeChange: (range: ChartRange) => void;
-  onClose: () => void;
-}) {
-  const [hoverPrice, setHoverPrice] = useState<number | null>(null);
-  const [hoverDate, setHoverDate] = useState<string | null>(null);
-  const { quote, history, loading } = stockData;
-  const isPositive = (quote?.change ?? 0) >= 0;
-
-  const relatedItems = useMemo(() => {
-    const matchTerms = [companyData.canonical_name.toLowerCase(), ...(companyData.entity_aliases || []).map((a) => a.alias.toLowerCase())];
-    return items
-      .filter((item) => {
-        const tags = (item.tags as Record<string, string[]>) || {};
-        const companies = (tags.company || []).map((c) => c.toLowerCase());
-        return companies.some((c) => matchTerms.some((term) => c.includes(term) || term.includes(c)));
-      })
-      .slice(0, 6);
-  }, [companyData, items]);
-
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [onClose]);
-
-  return (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      
-      <div className="relative bg-ast-surface border border-ast-border rounded-lg shadow-2xl w-[680px] max-w-[95vw] max-h-[90vh] overflow-hidden flex flex-col">
-        {/* Header */}
-        <div className="px-5 py-4 border-b border-ast-border flex items-center justify-between flex-shrink-0">
-          <div>
-            <h2 className="text-lg font-semibold text-ast-text">{companyData.canonical_name}</h2>
-            <div className="flex items-center gap-2">
-              <span className="text-ast-accent text-sm">{companyData.ticker}</span>
-              <span className="text-ast-muted text-xs">· {companyData.exchange}</span>
-            </div>
-          </div>
-          <button onClick={onClose} className="w-8 h-8 rounded border border-ast-border text-ast-muted hover:text-ast-text flex items-center justify-center">✕</button>
-        </div>
-
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto p-5">
-          {loading && !quote ? (
-            <div className="text-ast-muted text-sm animate-pulse">Loading market data...</div>
-          ) : (
-            <>
-              {/* Price - updates on hover */}
-              {quote && (
-                <div className="mb-4">
-                  <span className="text-3xl font-semibold text-ast-text">
-                    {formatCurrency(hoverPrice ?? quote.price, quote.currency)}
-                  </span>
-                  {hoverDate ? (
-                    <span className="ml-3 text-sm text-ast-muted">
-                      {new Date(hoverDate).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
-                    </span>
-                  ) : (
-                    <span className={`ml-3 text-sm font-medium ${isPositive ? "text-ast-mint" : "text-ast-pink"}`}>
-                      {isPositive ? "▲" : "▼"} {formatCurrency(Math.abs(quote.change), quote.currency)} ({quote.changePercent.toFixed(2)}%)
-                    </span>
-                  )}
-                </div>
-              )}
-
-              {/* Stats row */}
-              {quote && (
-                <div className="grid grid-cols-3 gap-3 mb-4 p-3 bg-ast-bg/50 rounded border border-ast-border/50">
-                  {quote.marketCap > 0 && (
-                    <div className="text-center">
-                      <div className="text-sm font-medium text-ast-text">{formatMarketCap(quote.marketCap)}</div>
-                      <div className="text-[10px] text-ast-muted">Market Cap</div>
-                    </div>
-                  )}
-                  <div className="text-center">
-                    <div className="text-sm font-medium text-ast-text">{formatCurrency(quote.fiftyTwoWeekHigh, quote.currency)}</div>
-                    <div className="text-[10px] text-ast-muted">52W High</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="text-sm font-medium text-ast-text">{formatCurrency(quote.fiftyTwoWeekLow, quote.currency)}</div>
-                    <div className="text-[10px] text-ast-muted">52W Low</div>
-                  </div>
-                </div>
-              )}
-
-              {/* Chart */}
-              <div className="mb-4">
-                <div className="flex items-center justify-between mb-2">
-                  <span className="text-xs text-ast-muted uppercase">Price History</span>
-                  <div className="flex gap-0.5 text-[10px]">
-                    {(Object.keys(RANGE_CONFIG) as ChartRange[]).map((r) => (
-                      <button
-                        key={r}
-                        onClick={() => onRangeChange(r)}
-                        className={`px-1.5 py-0.5 rounded transition-colors ${
-                          chartRange === r ? "text-ast-accent font-medium" : "text-ast-muted hover:text-ast-text"
-                        }`}
-                      >
-                        {RANGE_CONFIG[r].label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                <div className="h-48 bg-ast-bg/50 rounded overflow-hidden">
-                  {history.length > 0 ? (
-                    <InteractiveChart 
-                      history={history} 
-                      isPositive={isPositive} 
-                      height={192} 
-                      previousClose={quote?.previousClose} 
-                      onHover={(price, date) => { setHoverPrice(price); setHoverDate(date); }}
-                    />
-                  ) : (
-                    <div className="h-full flex items-center justify-center text-ast-muted text-xs">No chart data</div>
-                  )}
-                </div>
-              </div>
-
-              {/* IR Links */}
-              {companyData.ir_url && (
-                <div className="flex gap-2 mb-4">
-                  <a href={companyData.ir_url} target="_blank" rel="noopener noreferrer" className="flex-1 px-3 py-2 bg-ast-bg border border-ast-border rounded text-xs text-ast-muted hover:text-ast-accent text-center">📊 Investor Relations</a>
-                  {companyData.sec_url && (
-                    <a href={companyData.sec_url} target="_blank" rel="noopener noreferrer" className="flex-1 px-3 py-2 bg-ast-bg border border-ast-border rounded text-xs text-ast-muted hover:text-ast-accent text-center">📄 SEC Filings</a>
-                  )}
-                </div>
-              )}
-
-              {/* Recent coverage */}
-              <div>
-                <div className="text-xs text-ast-accent uppercase font-semibold mb-2">Recent Coverage ({relatedItems.length})</div>
-                {relatedItems.length === 0 ? (
-                  <p className="text-ast-muted text-xs">No recent coverage found.</p>
-                ) : (
-                  <div className="space-y-2.5">
-                    {relatedItems.map((item) => (
-                      <a key={item.id} href={item.url} target="_blank" rel="noopener noreferrer" className="block group">
-                        <p className="text-xs text-ast-text group-hover:text-ast-accent line-clamp-2 leading-snug">{item.title}</p>
-                        <div className="flex items-center gap-2 mt-0.5">
-                          <span className="text-[10px] text-ast-muted">{item.sources?.name}</span>
-                          <TimeAgo date={item.published_at} className="text-[10px] text-ast-muted" />
-                        </div>
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </div>
-      </div>
     </div>
   );
 }
@@ -967,7 +787,7 @@ function IndexOverview({
   );
 }
 
-export function CompanyTray({ items, selectedCompany, onSelectCompany }: CompanyTrayProps) {
+export function CompanyTray({ items }: CompanyTrayProps) {
   const [activeBasket, setActiveBasket] = useState<string>("AS Index");
   const [stockDataMap, setStockDataMap] = useState<Record<string, StockData>>({});
   const [chartRange, setChartRange] = useState<ChartRange>("1mo");
@@ -1056,24 +876,6 @@ export function CompanyTray({ items, selectedCompany, onSelectCompany }: Company
     });
   }, [basketCompanies, chartRange]);
 
-  // Refetch when chart range changes for expanded company
-  useEffect(() => {
-    if (!selectedCompany) return;
-    const companyData = basketEntityMap[selectedCompany] ?? null;
-    if (!companyData?.ticker) return;
-
-    const config = RANGE_CONFIG[chartRange];
-    const ticker = companyData.ticker;
-    fetch(`/api/stock/${ticker}?range=${config.range}&interval=${config.interval}`)
-      .then((res) => res.json())
-      .then((data) => {
-        setStockDataMap((prev) => ({
-          ...prev,
-          [ticker]: { quote: data.quote || null, history: data.history || [], loading: false },
-        }));
-      })
-      .catch(() => {});
-  }, [selectedCompany, chartRange]);
 
   const getStockData = (ticker: string | undefined): StockData => {
     if (!ticker) return { quote: null, history: [], loading: false };
@@ -1082,9 +884,6 @@ export function CompanyTray({ items, selectedCompany, onSelectCompany }: Company
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-
-  // Selected company data for modal
-  const selectedCompanyData = selectedCompany ? (basketEntityMap[selectedCompany] ?? null) : null;
 
   // Calculate index data for modal (same logic as IndexOverview)
   const indexDataForModal = useMemo(() => {
@@ -1190,10 +989,7 @@ export function CompanyTray({ items, selectedCompany, onSelectCompany }: Company
           {basketNames.map((name) => (
             <button
               key={name}
-              onClick={() => {
-                setActiveBasket(name);
-                onSelectCompany(null);
-              }}
+              onClick={() => setActiveBasket(name)}
               className={`px-2 py-1 text-[10px] rounded border transition-colors ${
                 activeBasket === name
                   ? "border-ast-accent text-ast-accent bg-ast-accent/10"
@@ -1236,26 +1032,11 @@ export function CompanyTray({ items, selectedCompany, onSelectCompany }: Company
                 companyData={data}
                 stockData={getStockData(data?.ticker ?? undefined)}
                 mentionCount={mentions}
-                isExpanded={selectedCompany === name}
-                onClick={() => onSelectCompany(name)}
               />
             ))
           }
         </div>
       </div>
-
-      {/* Company Modal portal */}
-      {mounted && selectedCompany && selectedCompanyData && createPortal(
-        <CompanyModal
-          companyData={selectedCompanyData}
-          stockData={getStockData(selectedCompanyData.ticker ?? undefined)}
-          items={items}
-          chartRange={chartRange}
-          onRangeChange={setChartRange}
-          onClose={() => onSelectCompany(null)}
-        />,
-        document.body
-      )}
 
       {/* Index Modal portal */}
       {mounted && showIndexModal && indexDataForModal && createPortal(

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -81,7 +81,7 @@ export function LiveFeed({ initialItems, initialHasMore, sources }: LiveFeedProp
   const [panels, setPanels] = useState<PanelVisibility>({ feed: true, signal: true, companies: true });
   
   // Company tray state
-  const [selectedCompany, setSelectedCompany] = useState<string | null>(null);
+
   
   const containerRef = useRef<HTMLDivElement>(null);
   const rightPaneRef = useRef<HTMLDivElement>(null);
@@ -421,12 +421,10 @@ export function LiveFeed({ initialItems, initialHasMore, sources }: LiveFeedProp
       content: (
         <CompanyTray
           items={items}
-          selectedCompany={selectedCompany}
-          onSelectCompany={setSelectedCompany}
         />
       ),
     },
-  ], [items, sources, hasMore, loadingMore, loadMore, selectedCompany]);
+  ], [items, sources, hasMore, loadingMore, loadMore]);
 
   // Mobile view
   if (isMobile) {
@@ -553,8 +551,6 @@ export function LiveFeed({ initialItems, initialHasMore, sources }: LiveFeedProp
                 <CompanyTrayBoundary>
                   <CompanyTray 
                     items={items} 
-                    selectedCompany={selectedCompany}
-                    onSelectCompany={setSelectedCompany}
                   />
                 </CompanyTrayBoundary>
               </div>


### PR DESCRIPTION
Removes CompanyTray's internal CompanyModal and routes all company card clicks to the existing right-side CompanyDrawer. ~230 lines deleted, consistent UX, build passes clean.

Closes kanban t_66d64e2d.