### PR TITLE
fix: header full-width layout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -106,7 +106,7 @@ export function Header() {
 
   return (
     <header className="h-12 sm:h-14 border-b border-ast-border sticky top-0 z-50 bg-ast-bg/95 backdrop-blur-sm">
-      <div className="h-full max-w-5xl mx-auto px-3 sm:px-4 flex items-center justify-between">
+      <div className="h-full px-3 sm:px-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Image
             src="/logo.png"


### PR DESCRIPTION
Logo/title was floating visually because header used `max-w-5xl mx-auto` while feed content spans full width. Drops the max-width constraint so logo aligns with leftmost content and nav icons hug the right edge.