### PR TITLE
fix: remove sources!inner join from extract-signals — 500 on pipeline tab

### DIFF
--- a/src/app/api/admin/extract-signals/route.ts
+++ b/src/app/api/admin/extract-signals/route.ts
@@ -97,7 +97,7 @@ export async function POST(req: NextRequest) {
 
   const { data: items, error: fetchError } = await supabase
     .from("content")
-    .select("id, title, body, tags, sources!inner(source_type)")
+    .select("id, title, body, tags")
     .order("published_at", { ascending: false, nullsFirst: false })
     .limit(200);
 


### PR DESCRIPTION
## Problem
The admin Pipeline tab was returning HTTP 500 when clicking Run Extraction.

## Root cause
`extract-signals/route.ts` was using `sources!inner(source_type)` in the Supabase select query. PostgREST resolves join syntax (`table!inner`) via FK metadata. The `content.source_id` column exists but has no FK constraint registered in the DB (`Relationships: []` in `database.types.ts`), so PostgREST 500s.

`source_type` was also never used in any filtering logic — pure dead weight.

## Fix
Drop the join. Select `id, title, body, tags` only.