### PR TITLE
fix: chart Prev label, news marker hover, company dropdown dedup

### DIFF
--- a/src/app/api/v1/entity-aliases/route.ts
+++ b/src/app/api/v1/entity-aliases/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+export const runtime = "nodejs";
+
+/**
+ * Public endpoint — returns all alias→canonical_name mappings for client-side
+ * company tag normalization. No auth required (data is non-sensitive).
+ * Used by Feed.tsx to deduplicate company tag variants in the filter dropdown.
+ */
+export async function GET() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } }
+  );
+
+  const { data, error } = await supabase
+    .from("entity_aliases")
+    .select("alias, entities!inner(canonical_name)");
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Build flat alias → canonical_name map
+  const map: Record<string, string> = {};
+  for (const row of data ?? []) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const canonical = (row as any).entities?.canonical_name;
+    if (canonical) map[row.alias.toLowerCase()] = canonical;
+  }
+
+  return NextResponse.json({ aliases: map });
+}

--- a/src/components/CompanyDrawer.tsx
+++ b/src/components/CompanyDrawer.tsx
@@ -101,6 +101,7 @@ function InteractiveChart({
   const svgRef = useRef<SVGSVGElement>(null);
   const [hoverX, setHoverX] = useState<number | null>(null);
   const [activeMarker, setActiveMarker] = useState<NewsMarker | null>(null);
+  const [hoveredMarkerId, setHoveredMarkerId] = useState<string | null>(null);
 
   // Compute chart data (always, for hooks stability)
   const padding = { top: 12, bottom: 20, left: 8, right: 8 };
@@ -279,29 +280,17 @@ function InteractiveChart({
 
         {/* Previous close reference line */}
         {prevCloseY !== null && (
-          <>
-            <line
-              x1={padding.left}
-              y1={prevCloseY}
-              x2={width - padding.right}
-              y2={prevCloseY}
-              stroke="#666"
-              strokeWidth="1"
-              strokeDasharray="3,3"
-              vectorEffect="non-scaling-stroke"
-              opacity="0.5"
-            />
-            <text
-              x={width - padding.right - 1}
-              y={prevCloseY - 2}
-              fill="#666"
-              fontSize="6"
-              textAnchor="end"
-              style={{ fontFamily: "system-ui" }}
-            >
-              Prev
-            </text>
-          </>
+          <line
+            x1={padding.left}
+            y1={prevCloseY}
+            x2={width - padding.right}
+            y2={prevCloseY}
+            stroke="#555"
+            strokeWidth="1"
+            strokeDasharray="3,3"
+            vectorEffect="non-scaling-stroke"
+            opacity="0.4"
+          />
         )}
 
         {/* Filled area under line */}
@@ -336,18 +325,20 @@ function InteractiveChart({
               strokeWidth="1"
               strokeDasharray="2,2"
               vectorEffect="non-scaling-stroke"
-              opacity="0.6"
+              opacity="0.5"
             />
             {/* Marker dot */}
             <circle
               cx={marker.x}
               cy={marker.y}
-              r="4"
+              r={hoveredMarkerId === marker.item.id ? 5.5 : 3.5}
               fill="#fbbf24"
               stroke="#0d1117"
               strokeWidth="1.5"
               vectorEffect="non-scaling-stroke"
-              className="transition-transform hover:scale-150"
+              style={{ transition: "r 0.15s ease" }}
+              onMouseEnter={() => setHoveredMarkerId(marker.item.id)}
+              onMouseLeave={() => setHoveredMarkerId(null)}
             />
           </g>
         ))}

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -49,8 +49,9 @@ interface FeedProps {
 
 /**
  * Compute tag counts from the actual loaded items.
+ * aliasMap: alias (lowercase) → canonical_name — normalizes company tag variants
  */
-function computeTagCounts(items: FeedItem[]): Record<string, Record<string, number>> {
+function computeTagCounts(items: FeedItem[], aliasMap?: Map<string, string>): Record<string, Record<string, number>> {
   const counts: Record<string, Record<string, number>> = {
     _sources: {},
   };
@@ -66,7 +67,11 @@ function computeTagCounts(items: FeedItem[]): Record<string, Record<string, numb
       if (!Array.isArray(values)) continue;
       if (!counts[dim]) counts[dim] = {};
       for (const v of values) {
-        counts[dim][v] = (counts[dim][v] || 0) + 1;
+        // Normalize company tags through alias map to deduplicate variants
+        const normalized = (dim === "company" && aliasMap)
+          ? (aliasMap.get(v.toLowerCase()) ?? v)
+          : v;
+        counts[dim][normalized] = (counts[dim][normalized] || 0) + 1;
       }
     }
   }
@@ -234,6 +239,21 @@ export function Feed({ items, sources, hasMore, loadingMore, onLoadMore, filters
 
   const [sortMode, setSortMode] = useState<SortMode>("importance");
   const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // Entity alias map for company tag normalization (alias lowercase → canonical_name)
+  const [entityAliasMap, setEntityAliasMap] = useState<Map<string, string>>(new Map());
+  useEffect(() => {
+    fetch("/api/v1/entity-aliases")
+      .then((r) => r.ok ? r.json() : null)
+      .then((json) => {
+        if (!json?.aliases) return;
+        const map = new Map<string, string>(
+          Object.entries(json.aliases as Record<string, string>)
+        );
+        setEntityAliasMap(map);
+      })
+      .catch(() => {});
+  }, []);
   
   // Collapsible date sections
   const [collapsedDates, setCollapsedDates] = useState<Set<string>>(new Set());
@@ -285,7 +305,7 @@ export function Feed({ items, sources, hasMore, loadingMore, onLoadMore, filters
     return () => observer.disconnect();
   }, [onLoadMore, hasMore, loadingMore]);
 
-  const tagCounts = useMemo(() => computeTagCounts(items), [items]);
+  const tagCounts = useMemo(() => computeTagCounts(items, entityAliasMap), [items, entityAliasMap]);
 
   const filtered = useMemo(
     () => items.filter((item) => matchesFilter(item, filters)),


### PR DESCRIPTION
- Remove 'Prev' text label from prev-close reference line
- Fix stuck yellow news marker (hover:scale-150 → state-based r change)
- Add /api/v1/entity-aliases public endpoint
- Feed.tsx fetches alias map on mount, normalizes company tags to canonical names in computeTagCounts → deduplicates Xbox/Xbox Game Studios/Microsoft into one entry