### PR TITLE
debug: expose pipeline 500 error detail

### DIFF
--- a/src/app/api/admin/pipeline/route.ts
+++ b/src/app/api/admin/pipeline/route.ts
@@ -249,9 +249,10 @@ export async function GET(req: NextRequest) {
       signalTimeSeries,
     });
   } catch (error) {
-    console.error("Pipeline stats error:", error);
+    const msg = error instanceof Error ? error.message : JSON.stringify(error);
+    console.error("Pipeline stats error:", msg, error);
     return NextResponse.json(
-      { error: "Failed to fetch pipeline stats" },
+      { error: "Failed to fetch pipeline stats", detail: msg },
       { status: 500 }
     );
   }


### PR DESCRIPTION
Temporary debug change — exposes the actual error message in the 500 response body so we can identify which query is failing without needing Vercel runtime logs. Remove once root cause is identified.